### PR TITLE
move away from database-specific naming

### DIFF
--- a/tests/test_data_store_initialise.py
+++ b/tests/test_data_store_initialise.py
@@ -8,9 +8,9 @@ from unittest import TestCase
 
 class TestDataStoreInitialisePostgres(TestCase):
     def setUp(self):
-        self.postgres = None
+        self.store = None
         try:
-            self.postgres = Postgresql(
+            self.store = Postgresql(
                 database="test", host="localhost", user="postgres", port=55527
             )
         except RuntimeError:
@@ -19,13 +19,13 @@ class TestDataStoreInitialisePostgres(TestCase):
 
     def tearDown(self):
         try:
-            self.postgres.stop()
+            self.store.stop()
         except AttributeError:
             return
 
     def test_postgres_initialise(self):
         """Test whether schemas created successfully on PostgresSQL"""
-        if self.postgres is None:
+        if self.store is None:
             self.skipTest("Postgres is not available. Test is skipping")
 
         data_store_postgres = DataStore(

--- a/tests/test_data_store_populate.py
+++ b/tests/test_data_store_populate.py
@@ -10,8 +10,8 @@ TEST_DATA_PATH = os.path.join(FILE_PATH, "sample_data", "csv_files")
 
 class TestDataStorePopulate(TestCase):
     def setUp(self):
-        self.sqlite = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
-        self.sqlite.initialise()
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
 
     def tearDown(self):
         pass
@@ -20,24 +20,24 @@ class TestDataStorePopulate(TestCase):
         """Test whether CSVs successfully imported to SQLite"""
 
         # Check tables are created but empty
-        with self.sqlite.session_scope() as session:
-            nationalities = self.sqlite.get_nationalities()
-            platform_types = self.sqlite.get_platform_types()
+        with self.store.session_scope() as session:
+            nationalities = self.store.get_nationalities()
+            platform_types = self.store.get_platform_types()
 
         # There must be no entities at the beginning
         self.assertEqual(len(nationalities), 0)
         self.assertEqual(len(platform_types), 0)
 
         # Import CSVs to the related tables
-        with self.sqlite.session_scope() as session:
-            self.sqlite.populate_reference(TEST_DATA_PATH)
+        with self.store.session_scope() as session:
+            self.store.populate_reference(TEST_DATA_PATH)
 
         # Check tables filled with correct data
-        with self.sqlite.session_scope() as session:
-            nationalities = self.sqlite.get_nationalities()
-            platform_types = self.sqlite.get_platform_types()
-            nationality_object = self.sqlite.search_nationality("UNITED KINGDOM")
-            platform_type_object = self.sqlite.search_platform_type("TYPE-1")
+        with self.store.session_scope() as session:
+            nationalities = self.store.get_nationalities()
+            platform_types = self.store.get_platform_types()
+            nationality_object = self.store.search_nationality("UNITED KINGDOM")
+            platform_type_object = self.store.search_platform_type("TYPE-1")
 
             # Check whether they are not empty anymore and filled with correct data
             self.assertNotEqual(len(nationalities), 0)
@@ -48,14 +48,14 @@ class TestDataStorePopulate(TestCase):
 
     def test_populate_metadata(self):
         # reference tables must be filled first
-        with self.sqlite.session_scope() as session:
-            self.sqlite.populate_reference(TEST_DATA_PATH)
+        with self.store.session_scope() as session:
+            self.store.populate_reference(TEST_DATA_PATH)
 
         # get all table values
-        with self.sqlite.session_scope() as session:
-            platforms = self.sqlite.get_platforms()
-            datafiles = self.sqlite.get_datafiles()
-            sensors = self.sqlite.get_sensors()
+        with self.store.session_scope() as session:
+            platforms = self.store.get_platforms()
+            datafiles = self.store.get_datafiles()
+            sensors = self.store.get_sensors()
 
         # There must be no entities at the beginning
         self.assertEqual(len(platforms), 0)
@@ -63,17 +63,17 @@ class TestDataStorePopulate(TestCase):
         self.assertEqual(len(sensors), 0)
 
         # Import CSVs to the related tables
-        with self.sqlite.session_scope() as session:
-            self.sqlite.populate_metadata(TEST_DATA_PATH)
+        with self.store.session_scope() as session:
+            self.store.populate_metadata(TEST_DATA_PATH)
 
-        with self.sqlite.session_scope() as session:
-            platforms = self.sqlite.get_platforms()
-            datafiles = self.sqlite.get_datafiles()
-            sensors = self.sqlite.get_sensors()
+        with self.store.session_scope() as session:
+            platforms = self.store.get_platforms()
+            datafiles = self.store.get_datafiles()
+            sensors = self.store.get_sensors()
 
-            platform_object = self.sqlite.search_platform("PLATFORM-1")
-            datafile_object = self.sqlite.search_datafile("DATAFILE-1")
-            sensor_object = self.sqlite.search_sensor("SENSOR-1")
+            platform_object = self.store.search_platform("PLATFORM-1")
+            datafile_object = self.store.search_datafile("DATAFILE-1")
+            sensor_object = self.store.search_sensor("SENSOR-1")
 
             # Check whether they are not empty anymore and filled with correct data
             self.assertNotEqual(len(platforms), 0)
@@ -85,19 +85,19 @@ class TestDataStorePopulate(TestCase):
 
             # Platform Object: PLATFORM-1, UNITED KINGDOM, TYPE-1, PRIVACY-1
             nationality = (
-                self.sqlite.session.query(self.sqlite.db_classes.Nationality)
+                self.store.session.query(self.store.db_classes.Nationality)
                 .filter_by(nationality_id=platform_object.nationality_id)
                 .first()
             )
             self.assertEqual(nationality.name, "UNITED KINGDOM")
             platform_type = (
-                self.sqlite.session.query(self.sqlite.db_classes.PlatformType)
+                self.store.session.query(self.store.db_classes.PlatformType)
                 .filter_by(platform_type_id=platform_object.platform_type_id)
                 .first()
             )
             self.assertEqual(platform_type.name, "TYPE-1")
             privacy = (
-                self.sqlite.session.query(self.sqlite.db_classes.Privacy)
+                self.store.session.query(self.store.db_classes.Privacy)
                 .filter_by(privacy_id=platform_object.privacy_id)
                 .first()
             )
@@ -106,13 +106,13 @@ class TestDataStorePopulate(TestCase):
             # Datafile Object: DATAFILE-1, True, PRIVACY-1, DATAFILE-TYPE-1
             self.assertEqual(datafile_object.simulated, True)
             privacy = (
-                self.sqlite.session.query(self.sqlite.db_classes.Privacy)
+                self.store.session.query(self.store.db_classes.Privacy)
                 .filter_by(privacy_id=datafile_object.privacy_id)
                 .first()
             )
             self.assertEqual(privacy.name, "PRIVACY-1")
             datafile_type = (
-                self.sqlite.session.query(self.sqlite.db_classes.DatafileType)
+                self.store.session.query(self.store.db_classes.DatafileType)
                 .filter_by(datafile_type_id=datafile_object.datafile_type_id)
                 .first()
             )
@@ -120,13 +120,13 @@ class TestDataStorePopulate(TestCase):
 
             # Sensor Object: SENSOR-1, SENSOR-TYPE-1, PLATFORM-1
             sensor_type = (
-                self.sqlite.session.query(self.sqlite.db_classes.SensorType)
+                self.store.session.query(self.store.db_classes.SensorType)
                 .filter_by(sensor_type_id=sensor_object.sensor_type_id)
                 .first()
             )
             self.assertEqual(sensor_type.name, "SENSOR-TYPE-1")
             platform = (
-                self.sqlite.session.query(self.sqlite.db_classes.Platform)
+                self.store.session.query(self.store.db_classes.Platform)
                 .filter_by(platform_id=sensor_object.platform_id)
                 .first()
             )


### PR DESCRIPTION
In #5 , Ian mistakenly believed we were using database specific API calls. But, that was just variable naming.

This PR removes the confusion, swapping `store` for `sqlite`.