### PR TITLE
Indicate that the `index` is our master doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,3 +68,6 @@ html_static_path = ["_static"]
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# index is our root, not the contents
+master_doc = "index"


### PR DESCRIPTION
Tell read-the-docs that `index` is our root file