### PR TITLE
Include path for spatialite DLL

### DIFF
--- a/pepys_import/utils/geoalchemy_utils.py
+++ b/pepys_import/utils/geoalchemy_utils.py
@@ -6,8 +6,7 @@ if SYSTEM == "Linux":
 elif SYSTEM == "Darwin":  # Darwin is MacOS
     EXTENSION_PATH = "/usr/local/lib/mod_spatialite.dylib"
 elif SYSTEM == "Windows":
-    # TODO: mod_spatialite path for Windows should be added
-    EXTENSION_PATH = None
+    EXTENSION_PATH = "mod_spatialite.dll"
 
 
 def load_spatialite(connection, connection_record):


### PR DESCRIPTION
Fixes #68 

Note: this fix works on the assumption that the spatialite DLL folder has been added to the MS Windows Path, as recommended in #67 