### PR TITLE
Hotfix/relax pre commit language version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.6


### PR DESCRIPTION
For Ubuntu LTS we're developing on 3.6.  But the pre-commit is failing since it wants 3.7.

I'm going to try to relax the language version, so we can use it on both.