### PR TITLE
Correctly represent point data

### DIFF
--- a/pepys_import/core/formats/location.py
+++ b/pepys_import/core/formats/location.py
@@ -30,6 +30,13 @@ class Location:
             and self.hemisphere == other.hemisphere
         )
 
+    # provide representation of this location element in whole degrees
+    def as_degrees(self):
+        degs = self.degrees + self.minutes / 60 + self.seconds / 3600
+        if self.hemisphere.upper() in ("S", "W"):
+            degs *= -1
+        return degs
+
     def parse(self):
         try:
             self.degrees = float(self.degrees)

--- a/pepys_import/core/formats/rep_line.py
+++ b/pepys_import/core/formats/rep_line.py
@@ -191,4 +191,4 @@ class REPLine:
         return self.vessel
 
     def get_location(self):
-        return f"POINT({self.longitude} {self.latitude})"
+        return f"POINT({self.longitude.as_degrees()} {self.latitude.as_degrees()})"


### PR DESCRIPTION
Submitting data to PostGIS was failing, because we were sending `POINT( (12 23.3 33.3 N) (33 32.3 23.3 E))` instead of `POINT(12.443, 33.43)`

Example:
```
sqlalchemy.exc.InternalError: (psycopg2.errors.InternalError_) parse error - invalid geometry
HINT:  "POINT((0" <-- parse error at position 8 within geometry

[SQL: INSERT INTO "States" (state_id, time, sensor_id, location, heading, course, speed, 
source_id, privacy_id, created_date) VALUES (%(state_id)s, %(time)s, %(sensor_id)s, 
ST_GeomFromEWKT(%(location)s), %(heading)s, %(course)s, %(speed)s, %(source_id)s, %
(privacy_id)s, %(created_date)s)]
[parameters: {'state_id': UUID('9638fcf8-71cf-4b4c-8d79-ec6164120411'), 'time': 
datetime.datetime(2010, 1, 12, 12, 8), 'sensor_id': UUID('6d5b4031-6dd4-4d88-a825-
5bbb623da232'), 'location': 'POINT((0.0, 1.0, 25.86, E) (60.0, 23.0, 40.25, N))', 'heading': 
1.9038051480754146, 'course': None, 'speed': 3.086666666666667, 'source_id': 
UUID('333c6de6-4476-438e-81cc-5ba5ffe8678a'), 'privacy_id': None, 'created_date': 
datetime.datetime(2020, 2, 19, 11, 23, 14, 272023)}]
(Background on this error at: http://sqlalche.me/e/2j85)
```