### PR TITLE
Solve SQLAlchemy OperationalError issue

### DIFF
--- a/tests/test_data_store_api_postgis.py
+++ b/tests/test_data_store_api_postgis.py
@@ -588,9 +588,10 @@ class DataStoreStatusTestCase(TestCase):
                 db_port=55527,
             )
             self.store.initialise()
-            self.store.populate_reference(TEST_DATA_PATH)
-            self.store.populate_metadata(TEST_DATA_PATH)
-            self.store.populate_measurement(TEST_DATA_PATH)
+            with self.store.session_scope():
+                self.store.populate_reference(TEST_DATA_PATH)
+                self.store.populate_metadata(TEST_DATA_PATH)
+                self.store.populate_measurement(TEST_DATA_PATH)
         except OperationalError:
             print("Database schema and data population failed! Test is skipping.")
 
@@ -606,7 +607,8 @@ class DataStoreStatusTestCase(TestCase):
     def test_get_status_of_measurement(self):
         """Test whether summary contents correct for measurement tables"""
 
-        table_summary_object = self.store.get_status(report_measurement=True)
+        with self.store.session_scope():
+            table_summary_object = self.store.get_status(report_measurement=True)
         report = table_summary_object.report()
 
         self.assertNotEqual(report, "")
@@ -617,7 +619,8 @@ class DataStoreStatusTestCase(TestCase):
     def test_get_status_of_metadata(self):
         """Test whether summary contents correct for metadata tables"""
 
-        table_summary_object = self.store.get_status(report_metadata=True)
+        with self.store.session_scope():
+            table_summary_object = self.store.get_status(report_metadata=True)
         report = table_summary_object.report()
 
         self.assertNotEqual(report, "")
@@ -628,7 +631,8 @@ class DataStoreStatusTestCase(TestCase):
     def test_get_status_of_reference(self):
         """Test whether summary contents correct for reference tables"""
 
-        table_summary_object = self.store.get_status(report_reference=True)
+        with self.store.session_scope():
+            table_summary_object = self.store.get_status(report_reference=True)
         report = table_summary_object.report()
 
         self.assertNotEqual(report, "")


### PR DESCRIPTION
This PR solves the following issue:

```bash
Traceback (most recent call last):
  File "c:\IanMayo\pepys-import\venv\lib\site-packages\sqlalchemy\pool\base.py", line 680, in _finalize_fairy
    fairy._reset(pool)
  File "c:\IanMayo\pepys-import\venv\lib\site-packages\sqlalchemy\pool\base.py", line 867, in _reset
    pool._dialect.do_rollback(self)
  File "c:\IanMayo\pepys-import\venv\lib\site-packages\sqlalchemy\engine\default.py", line 530, in do_rollback
    dbapi_connection.rollback()
psycopg2.OperationalError: server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
```