### PR TITLE
Tidied up presentation of table summary displays

### DIFF
--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -106,7 +106,9 @@ class DataStore(object):
             show_welcome_banner(welcome_text)
         if self.show_status:
             show_software_meta_info(__version__, self.db_type, self.db_name, db_host)
-            print("---------------------------------")
+            # The 'pepys-import' banner is 61 characters wide, so making a line
+            # of the same length makes things prettier
+            print("-"*61)
 
     def initialise(self):
         """Create schemas for the database

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -108,7 +108,7 @@ class DataStore(object):
             show_software_meta_info(__version__, self.db_type, self.db_name, db_host)
             # The 'pepys-import' banner is 61 characters wide, so making a line
             # of the same length makes things prettier
-            print("-"*61)
+            print("-" * 61)
 
     def initialise(self):
         """Create schemas for the database

--- a/pepys_import/core/store/table_summary.py
+++ b/pepys_import/core/store/table_summary.py
@@ -63,7 +63,7 @@ class TableSummarySet(object):
         """
         res = ""
         if title:
-            res += title
+            res += title + "\n"
         res += tabulate(
             [
                 (table.table_name, table.number_of_rows, table.created_date)
@@ -72,6 +72,7 @@ class TableSummarySet(object):
             headers=self.headers,
             tablefmt="github",
         )
+        res += "\n"
         return res
 
     def compare_to(self, other: "TableSummarySet"):


### PR DESCRIPTION
This is a very minor PR that just makes things a bit prettier (they were niggling at me before...)

 - Changed header for overall table ('Before' or 'After') to come on a separate line
 - Altered line separator to be the same length as the pepys-import banner