### PR TITLE
Hotfix - fix minor black errors on Admin CLI

### DIFF
--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -4,11 +4,11 @@ import sys
 
 sys.path.append(".")
 
-import argparse     # noqa: E402
-import cmd          # noqa: E402
-from iterfzf import iterfzf      # noqa: E402
-import os                        # noqa: E402
-from pepys_import.core.store.data_store import DataStore   # noqa: E402
+import argparse  # noqa: E402
+import cmd  # noqa: E402
+from iterfzf import iterfzf  # noqa: E402
+import os  # noqa: E402
+from pepys_import.core.store.data_store import DataStore  # noqa: E402
 
 dirpath = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
Somehow I was getting black errors on files that had already been committed by someone else - possibly because of Windows line-ending issues. I've run black and committed the new results here.