### PR TITLE
Fixed finding of importers

### DIFF
--- a/pepys_import/file/file_processor.py
+++ b/pepys_import/file/file_processor.py
@@ -150,7 +150,7 @@ class FileProcessor:
 
             for importer in good_importers:
                 processed_ctr += 1
-                importer.load_this_file(data_store, file, file_contents, datafile)
+                importer.load_this_file(data_store, full_path, file_contents, datafile)
 
             if datafile.validate():
                 datafile.commit(data_store.session)
@@ -165,6 +165,16 @@ class FileProcessor:
         :type importer: Importer
         """
         self.importers.append(importer)
+
+    def register_importers(self, importers):
+        """Adds all the importers in the supplied list to the list of import modules
+
+        :param importers: A list of importers, each of which is an Importer class that inherits
+        from the Importer base class
+        :type importers: list
+        """
+        for importer in importers:
+            self.importers.append(importer)
 
     @staticmethod
     def get_first_line(file_path: str):

--- a/pepys_import/file/get_importers.py
+++ b/pepys_import/file/get_importers.py
@@ -1,0 +1,23 @@
+from pepys_import.file.replay_importer import ReplayImporter
+from pepys_import.file.nmea_importer import NMEAImporter
+from pepys_import.file.gpx_importer import GPXImporter
+from pepys_import.file.e_trac_importer import ETracImporter
+
+
+def get_importers():
+    """
+    Returns a list of importers to be added to the file_processor object.
+
+    At the moment this just returns the static list of importers that we include
+    with pepys-import. Later, this will dynamically find importers in various places
+    and add them to the list
+    """
+
+    STATIC_IMPORTERS = [
+        ReplayImporter(),
+        NMEAImporter(),
+        GPXImporter(),
+        ETracImporter(),
+    ]
+
+    return STATIC_IMPORTERS

--- a/pepys_import/file/gpx_importer.py
+++ b/pepys_import/file/gpx_importer.py
@@ -30,15 +30,15 @@ class GPXImporter(Importer):
         return True
 
     def load_this_file(self, data_store, path, file_contents, datafile):
-        print("GPX parser working on ", path.path)
+        print("GPX parser working on ", path)
 
         # Parse XML file from the full path of the file
         # Note: we can't use the file_contents variable passed in, as lxml refuses
         # to parse a string that has an encoding attribute in the XML - it requires bytes instead
         try:
-            doc = etree.parse(path.path)
+            doc = etree.parse(path)
         except Exception as e:
-            print(f'Invalid GPX file at {path.path}\nError from parsing was "{str(e)}"')
+            print(f'Invalid GPX file at {path}\nError from parsing was "{str(e)}"')
             return
 
         # Iterate through <trk> elements - these should correspond to

--- a/pepys_import/import.py
+++ b/pepys_import/import.py
@@ -14,7 +14,7 @@ def main(path=DIRECTORY_PATH, db=DEFAULT_DATABASE):
     data_store = DataStore("", "", "", 0, db_name=db, db_type="sqlite")
     data_store.initialise()
 
-    processor = FileProcessor("descending.db")
+    processor = FileProcessor()
 
     importers = get_importers()
     processor.register_importers(importers)

--- a/pepys_import/import.py
+++ b/pepys_import/import.py
@@ -3,8 +3,7 @@ import argparse
 
 from pepys_import.file.file_processor import FileProcessor
 from pepys_import.core.store.data_store import DataStore
-from pepys_import.file.nmea_importer import NMEAImporter
-from pepys_import.file.replay_importer import ReplayImporter
+from pepys_import.file.get_importers import get_importers
 
 FILE_PATH = os.path.abspath(__file__)
 DIRECTORY_PATH = os.path.dirname(FILE_PATH)
@@ -16,8 +15,10 @@ def main(path=DIRECTORY_PATH, db=DEFAULT_DATABASE):
     data_store.initialise()
 
     processor = FileProcessor("descending.db")
-    processor.register_importer(ReplayImporter())
-    processor.register_importer(NMEAImporter())
+
+    importers = get_importers()
+    processor.register_importers(importers)
+
     processor.process(path, data_store, True)
 
 

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -7,6 +7,7 @@ from pepys_import.file.importer import Importer
 from pepys_import.file.replay_importer import ReplayImporter
 from pepys_import.file.nmea_importer import NMEAImporter
 from pepys_import.file.file_processor import FileProcessor
+from pepys_import.file.get_importers import get_importers
 
 FILE_PATH = os.path.dirname(__file__)
 CURRENT_DIR = os.getcwd()
@@ -31,8 +32,8 @@ class SampleImporterTests(unittest.TestCase):
         """Test whether single level processing works for the given path"""
         processor = FileProcessor("single_level.db")
 
-        processor.register_importer(ReplayImporter())
-        processor.register_importer(NMEAImporter())
+        importers = get_importers()
+        processor.register_importers(importers)
 
         # try bad file
         exception = False
@@ -49,8 +50,8 @@ class SampleImporterTests(unittest.TestCase):
         """Test whether descending processing works for the given path"""
         processor = FileProcessor("descending.db")
 
-        processor.register_importer(ReplayImporter())
-        processor.register_importer(NMEAImporter())
+        importers = get_importers()
+        processor.register_importers(importers)
 
         # try bad file
         exception = False
@@ -67,8 +68,8 @@ class SampleImporterTests(unittest.TestCase):
         """Test whether :memory: is used when no filename is given"""
         processor = FileProcessor()
 
-        processor.register_importer(ReplayImporter())
-        processor.register_importer(NMEAImporter())
+        importers = get_importers()
+        processor.register_importers(importers)
 
         # try bad file
         exception = False
@@ -92,8 +93,8 @@ class SampleImporterTests(unittest.TestCase):
         """Test whether process method works when a file path is given"""
         processor = FileProcessor()
 
-        processor.register_importer(ReplayImporter())
-        processor.register_importer(NMEAImporter())
+        importers = get_importers()
+        processor.register_importers(importers)
 
         file_path = os.path.join(DATA_PATH, "test_importers.csv")
 


### PR DESCRIPTION
 - Now found through a get_importers() function
 - This function is now used in import.py and in the tests - so the tests more accurately reflect the real-worl
 - This function currently returns a list of parsers that are included in pepys-import - later this can be extended to dynamically load parsers
 - Tests have been updated to work with the new get_importers() function

This also found a bug in the way that paths were passed around to importers: just the filename was given to a parser rather than the full path. This was fine
for parsers that can use the file_contents variable to load the file, but the XML parser used in the GPX parser needs to load directly from a file due to
encoding issues, so it actually needs the full path. I've changed file_processor to pass the full_path to the parser, so parsers can use it if necessary (in the previous situation the full path was passed some of the time, and some of the time only the filename was passed, depending on the configuration of the file processor).