### PR TITLE
Fix error in pepys_import_persist when there are spaces in path

### DIFF
--- a/bin/pepys_import_persist.bat
+++ b/bin/pepys_import_persist.bat
@@ -1,1 +1,1 @@
-call pepys_import %1 --db %~dp1\pepys.db
+call pepys_import %1 --db "%~dp1\pepys.db"


### PR DESCRIPTION
This just needed quotes adding around the path to the database, and it all now works.