### PR TITLE
Change how we integrate PostGIS

### DIFF
--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -129,7 +129,7 @@ class DataStore(object):
                 # Create schema pepys and extension for PostGIS first
                 query = """
                     CREATE SCHEMA IF NOT EXISTS pepys;
-                    CREATE EXTENSION IF NOT EXISTS postgis SCHEMA pepys;
+                    CREATE EXTENSION IF NOT EXISTS postgis;
                     SET search_path = pepys,public;
                 """
                 with self.engine.connect() as conn:

--- a/tests/test_data_store_initialise.py
+++ b/tests/test_data_store_initialise.py
@@ -58,16 +58,20 @@ class DataStoreInitialisePostGISTestCase(TestCase):
         table_names = inspector.get_table_names(schema="pepys")
         schema_names = inspector.get_schema_names()
 
-        # 36 tables and 1 table for spatial objects (spatial_ref_sys) must be created to default schema
-        self.assertEqual(len(table_names), 35)
+        # 34 tables must be created to default schema
+        self.assertEqual(len(table_names), 34)
         self.assertIn("Platforms", table_names)
         self.assertIn("States", table_names)
         self.assertIn("Datafiles", table_names)
         self.assertIn("Nationalities", table_names)
-        self.assertIn("spatial_ref_sys", table_names)
 
         # pepys must be created
         self.assertIn("pepys", schema_names)
+
+        # 1 table for spatial objects (spatial_ref_sys) must be created to default schema
+        table_names = inspector.get_table_names()
+        self.assertEqual(len(table_names), 1)
+        self.assertIn("spatial_ref_sys", table_names)
 
 
 class DataStoreInitialiseSpatiaLiteTestCase(TestCase):


### PR DESCRIPTION
Fixes #176 

I've had an issue, where I can write data to a PostGIS database (in python), but I can't retrieve the data (in python).

With the support of @tahirs95 , and trial-and-error, we isolated the problem to the PostGIS configuration.  When I manually installed the PostGIS extensions (`CREATE EXTENSION postgis;`) it worked fine.

So, I looked at how we install PostGIS from Python, and I saw that were were inserting it into the Pepys schema (which sounded logical).  But, when I made the installation more general, it fixed the error.

I've tested this on Macos and Linux.  Aah, but I don't really know the detail of why it works.

Note: we don't have the issue for our `alwaysdata` remote hosting.  For that hosting, I had to use their tool to install PostGIS (since it required elevated privileges), so it didn't use/require our Python code to do it.