### PR TITLE
Fixed gitignore ignoring of output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,5 +117,6 @@ venv.bak/
 *.zip
 *.lnk
 
-# Log files produced by import code
-*.log
+# Any subfolders called 'output'
+# to ignore the output logs, error logs, highlighted files etc
+**/*output*/**


### PR DESCRIPTION
Removed the ignoring of .log files (fixing #175), and replaced with ignoring of the contents of any subfolder called `output`.