### PR TITLE
Fixed REP comment importer to import full message not just first word

### DIFF
--- a/pepys_import/file/replay_comment_importer.py
+++ b/pepys_import/file/replay_comment_importer.py
@@ -56,7 +56,7 @@ class ReplayCommentImporter(Importer):
                     date_token = tokens[1]
                     time_token = tokens[2]
                     vessel_name_token = tokens[3]
-                    message_token = tokens[4]
+                    message_tokens = tokens[4:]
                     comment_type = "None"
                 elif line.text.startswith(";NARRATIVE2:"):
                     # ok for for it
@@ -80,7 +80,7 @@ class ReplayCommentImporter(Importer):
                     comment_type_token.record(
                         self.name, "comment type", comment_type, "n/a"
                     )
-                    message_token = tokens[5]
+                    message_tokens = tokens[5:]
                 else:
                     continue
 
@@ -108,8 +108,10 @@ class ReplayCommentImporter(Importer):
                     self.name, "timestamp", timestamp, "n/a"
                 )
 
-                message = message_token.text
-                message_token.record(self.name, "message", message, "n/a")
+                message = " ".join([t.text for t in message_tokens])
+                combine_tokens(*message_tokens).record(
+                    self.name, "message", message, "n/a"
+                )
 
                 comment = datafile.create_comment(
                     platform_id=platform.platform_id,

--- a/tests/test_parse_rep_comment.py
+++ b/tests/test_parse_rep_comment.py
@@ -46,11 +46,14 @@ class RepCommentTests(unittest.TestCase):
             # there must be states after the import
             comments = self.store.session.query(self.store.db_classes.Comment).all()
             self.assertEqual(len(comments), 7)
-            # check the first two rows have different comment types
+            # check the first two rows have matching comment types (NULL)
             self.assertEqual(comments[0].comment_type_id, 1)
-            self.assertEqual(comments[0].comment_type_id, 1)
+            self.assertEqual(comments[1].comment_type_id, 1)
             # and the last row has a different comment type
             self.assertEqual(comments[6].comment_type_id, 2)
+            # and the full comments on some other rows
+            self.assertEqual(comments[0].content, "Contact detected on TA")
+            self.assertEqual(comments[6].content, "SUBJECT lost on TA")
 
             # there must be platforms after the import
             platforms = self.store.session.query(self.store.db_classes.Platform).all()


### PR DESCRIPTION
Fixes #178 

Highlighted output now looks like the attached. Can you check this is right @IanMayo - as you're the expert on REP files. It looks right to me though.
<img width="796" alt="Screen Shot 2020-03-10 at 10 02 03" src="https://user-images.githubusercontent.com/296686/76301635-7d101f80-62b6-11ea-892b-fda41f54bf80.png">
