### PR TITLE
Hotfixes - Fix tests for moving files, fix directory in error message for local parsers

### DIFF
--- a/pepys_import/file/file_processor.py
+++ b/pepys_import/file/file_processor.py
@@ -24,7 +24,7 @@ class FileProcessor:
         if LOCAL_PARSERS:
             if not os.path.exists(LOCAL_PARSERS):
                 print(
-                    f"No such file or directory: {local_importers_path}. Only core "
+                    f"No such file or directory: {LOCAL_PARSERS}. Only core "
                     "parsers are going to work."
                 )
             else:

--- a/tests/test_load_rep_contact.py
+++ b/tests/test_load_rep_contact.py
@@ -5,6 +5,8 @@ import math
 from sqlalchemy import func
 from geoalchemy2 import WKBElement
 
+from unittest.mock import patch
+
 from importers.replay_contact_importer import ReplayContactImporter
 from pepys_import.file.file_processor import FileProcessor
 from pepys_import.core.store.data_store import DataStore
@@ -27,7 +29,9 @@ class RepContactTests(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_process_rep_contacts(self):
+    @patch("shutil.move")
+    @patch("os.chmod")
+    def test_process_rep_contacts(self, patched_move, patched_chmod):
         processor = FileProcessor()
         processor.register_importer(ReplayContactImporter())
 
@@ -91,7 +95,9 @@ class RepContactTests(unittest.TestCase):
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
             self.assertEqual(len(datafiles), 1)
 
-    def test_process_dsf_contacts(self):
+    @patch("shutil.move")
+    @patch("os.chmod")
+    def test_process_dsf_contacts(self, patched_move, patched_chmod):
         processor = FileProcessor()
         processor.register_importer(ReplayContactImporter())
 


### PR DESCRIPTION
A few minor fixes:

1. The REP Contact parser tests moved the input files to the archive location, whereas most of the other tests have patched the move function so they don't actually do the moving. I've added this for the REP Contact parser, so files don't get moved every time the test is run.

2. It was impossible to run individual files inside `config_file_tests` because of path issues, so I added an `__init__.py` file to that folder (like all other test folders) to make it work properly with pytest.

3. There was an error in FileProcessor where it tried to use an invalid variable name in an error message - I've fixed this to point to the LOCAL_PARSERS variable.