### PR TITLE
Hotfix/Expire location attribute to fetch it from the DB

### DIFF
--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -206,6 +206,7 @@ class StateMixin:
         """Submit intermediate object to the DB"""
         session.add(self)
         session.flush()
+        session.expire(self, ["location"])
 
         return self
 
@@ -215,6 +216,7 @@ class ContactMixin:
         """Submit intermediate object to the DB"""
         session.add(self)
         session.flush()
+        session.expire(self, ["location"])
 
         return self
 

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -343,6 +343,7 @@ class DataStore(object):
         )
         self.session.add(state_obj)
         self.session.flush()
+        self.session.expire(self, ["location"])
 
         return state_obj
 

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -343,7 +343,7 @@ class DataStore(object):
         )
         self.session.add(state_obj)
         self.session.flush()
-        self.session.expire(self, ["location"])
+        self.session.expire(state_obj, ["location"])
 
         return state_obj
 


### PR DESCRIPTION
As @robintw mentioned on Slack, the `location` attribute was returning `String` or `WKBElement` in different test cases. It was happening because of the laziness of SQL Alchemy. State objects were inserted to the DB, however, they weren't fetched from it if you are using the same session. So, the `location` attribute was still a string. Therefore, `session.expire` added after the `session.flush`. Now, when a State object is called again in the same session, the location attribute is fetched from the DB. So, it is a `WKBElement` object.