### PR TITLE
Convert Contact attributes to properties with unit checking

### DIFF
--- a/importers/replay_contact_importer.py
+++ b/importers/replay_contact_importer.py
@@ -254,7 +254,6 @@ class ReplayContactImporter(Importer):
                         self.error_type,
                     )
                     range_token.record(self.name, "range", range_val, "yds")
-                    # TODO add range field to schema
                     contact.range = range_val
 
                 if freq_token is not None:

--- a/importers/replay_contact_importer.py
+++ b/importers/replay_contact_importer.py
@@ -2,7 +2,7 @@ from pepys_import.core.validators import constants
 from pepys_import.core.formats.rep_line import parse_timestamp
 from pepys_import.file.highlighter.support.combine import combine_tokens
 from pepys_import.utils.unit_utils import convert_absolute_angle
-from pepys_import.utils.unit_utils import convert_distance
+from pepys_import.utils.unit_utils import convert_distance, convert_frequency
 from pepys_import.core.formats import unit_registry
 from pepys_import.core.formats.location import Location
 from pepys_import.file.importer import Importer
@@ -150,7 +150,7 @@ class ReplayContactImporter(Importer):
                 if lat_degrees_token is None:
                     location = None
                 else:
-                    loc = Location(self.errors, self.error_type,)
+                    loc = Location(self.errors, self.error_type)
 
                     if not loc.set_latitude_dms(
                         lat_degrees_token.text,
@@ -243,7 +243,7 @@ class ReplayContactImporter(Importer):
 
                 # sort out the optional fields
                 if bearing is not None:
-                    contact.bearing = bearing.to(unit_registry.radian).magnitude
+                    contact.bearing = bearing
 
                 if range_token.text.upper() != "NULL":
                     range_val = convert_distance(
@@ -259,9 +259,15 @@ class ReplayContactImporter(Importer):
 
                 if freq_token is not None:
                     if freq_token.text.upper() != "NULL":
-                        freq = float(freq_token.text)
-                        freq_token.record(self.name, "frequency", freq, "Hz")
-                        contact.freq = freq
+                        freq_val = convert_frequency(
+                            freq_token.text,
+                            unit_registry.hertz,
+                            line,
+                            self.errors,
+                            self.error_type,
+                        )
+                        freq_token.record(self.name, "frequency", freq_val, "Hz")
+                        contact.freq = freq_val
 
                 if ambig_bearing_token is not None:
                     if ambig_bearing_token.text.upper() == "NULL":

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -530,9 +530,47 @@ class ContactMixin:
         # Set the actual bearing attribute to the given value converted to radians
         self._sla = sla.to(unit_registry.radian).magnitude
 
-    @sla.expression
-    def sla(self):
-        return self._sla
+    #
+    # Orientation properties
+    #
+
+    @hybrid_property
+    def orientation(self):
+        # Return all orientation's as degrees
+        if self._orientation is None:
+            return None
+        else:
+            return (self._orientation * unit_registry.radian).to(unit_registry.degree)
+
+    @orientation.setter
+    def orientation(self, orientation):
+        if orientation is None:
+            self._orientation = None
+            return
+
+        # Check the given orientation is a Quantity with a dimension of '' and units of
+        # degrees or radians
+        try:
+            if not orientation.check(""):
+                raise ValueError(
+                    "Orientation must be a Quantity with a dimensionality of '' (ie. nothing)"
+                )
+            if not (
+                orientation.units == unit_registry.degree
+                or orientation.units == unit_registry.radian
+            ):
+                raise ValueError(
+                    "Orientation must be a Quantity with angular units (degree or radian)"
+                )
+        except AttributeError:
+            raise TypeError("Orientation must be a Quantity")
+
+        # Set the actual bearing attribute to the given value converted to radians
+        self._orientation = orientation.to(unit_registry.radian).magnitude
+
+    @orientation.expression
+    def orientation(self):
+        return self._orientation
 
 
 class CommentMixin:

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -640,6 +640,40 @@ class ContactMixin:
     def minor(self):
         return self._minor
 
+    #
+    # Freq property
+    #
+
+    @hybrid_property
+    def freq(self):
+        # Return all freqs as Hz
+        if self._freq is None:
+            return None
+        else:
+            return self._freq * unit_registry.hertz
+
+    @freq.setter
+    def freq(self, freq):
+        if freq is None:
+            self._freq = None
+            return
+
+        # Check the given freq is a Quantity with a dimension of 'time^-1' (ie. 'per unit time')
+        try:
+            if not freq.check("[time]^-1"):
+                raise ValueError(
+                    "Freq must be a Quantity with a dimensionality of [time]^-1"
+                )
+        except AttributeError:
+            raise TypeError("Freq must be a Quantity")
+
+        # Set the actual freq attribute to the given value converted to hertz
+        self._freq = freq.to(unit_registry.hertz).magnitude
+
+    @freq.expression
+    def freq(self):
+        return self._freq
+
 
 class CommentMixin:
     def submit(self, data_store, change_id):

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -493,6 +493,47 @@ class ContactMixin:
     def mla(self):
         return self._mla
 
+    #
+    # SLA properties
+    #
+
+    @hybrid_property
+    def sla(self):
+        # Return all SLA's as degrees
+        if self._sla is None:
+            return None
+        else:
+            return (self._sla * unit_registry.radian).to(unit_registry.degree)
+
+    @sla.setter
+    def sla(self, sla):
+        if sla is None:
+            self._sla = None
+            return
+
+        # Check the given bearing is a Quantity with a dimension of '' and units of
+        # degrees or radians
+        try:
+            if not sla.check(""):
+                raise ValueError(
+                    "SLA must be a Quantity with a dimensionality of '' (ie. nothing)"
+                )
+            if not (
+                sla.units == unit_registry.degree or sla.units == unit_registry.radian
+            ):
+                raise ValueError(
+                    "SLA must be a Quantity with angular units (degree or radian)"
+                )
+        except AttributeError:
+            raise TypeError("SLA must be a Quantity")
+
+        # Set the actual bearing attribute to the given value converted to radians
+        self._sla = sla.to(unit_registry.radian).magnitude
+
+    @sla.expression
+    def sla(self):
+        return self._sla
+
 
 class CommentMixin:
     def submit(self, data_store, change_id):

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -606,6 +606,40 @@ class ContactMixin:
     def major(self):
         return self._major
 
+    #
+    # Minor property
+    #
+
+    @hybrid_property
+    def minor(self):
+        # Return all minors as metres
+        if self._minor is None:
+            return None
+        else:
+            return self._minor * unit_registry.metre
+
+    @minor.setter
+    def minor(self, minor):
+        if minor is None:
+            self._minor = None
+            return
+
+        # Check the given minor is a Quantity with a dimension of 'length'
+        try:
+            if not minor.check("[length]"):
+                raise ValueError(
+                    "Minor must be a Quantity with a dimensionality of [length]"
+                )
+        except AttributeError:
+            raise TypeError("Minor must be a Quantity")
+
+        # Set the actual minor attribute to the given value converted to metres
+        self._minor = minor.to(unit_registry.metre).magnitude
+
+    @minor.expression
+    def minor(self):
+        return self._minor
+
 
 class CommentMixin:
     def submit(self, data_store, change_id):

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -368,6 +368,48 @@ class ContactMixin:
         )
         return self
 
+    #
+    # Bearing properties
+    #
+
+    @hybrid_property
+    def bearing(self):
+        # Return all bearings as degrees
+        if self._bearing is None:
+            return None
+        else:
+            return (self._bearing * unit_registry.radian).to(unit_registry.degree)
+
+    @bearing.setter
+    def bearing(self, bearing):
+        if bearing is None:
+            self._bearing = None
+            return
+
+        # Check the given bearing is a Quantity with a dimension of '' and units of
+        # degrees or radians
+        try:
+            if not bearing.check(""):
+                raise ValueError(
+                    "Bearing must be a Quantity with a dimensionality of '' (ie. nothing)"
+                )
+            if not (
+                bearing.units == unit_registry.degree
+                or bearing.units == unit_registry.radian
+            ):
+                raise ValueError(
+                    "Bearing must be a Quantity with angular units (degree or radian)"
+                )
+        except AttributeError:
+            raise TypeError("Bearing must be a Quantity")
+
+        # Set the actual bearing attribute to the given value converted to radians
+        self._bearing = bearing.to(unit_registry.radian).magnitude
+
+    @bearing.expression
+    def bearing(self):
+        return self._bearing
+
 
 class CommentMixin:
     def submit(self, data_store, change_id):

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -452,6 +452,47 @@ class ContactMixin:
     def rel_bearing(self):
         return self._rel_bearing
 
+    #
+    # MLA properties
+    #
+
+    @hybrid_property
+    def mla(self):
+        # Return all MLA's as degrees
+        if self._mla is None:
+            return None
+        else:
+            return (self._mla * unit_registry.radian).to(unit_registry.degree)
+
+    @mla.setter
+    def mla(self, mla):
+        if mla is None:
+            self._mla = None
+            return
+
+        # Check the given bearing is a Quantity with a dimension of '' and units of
+        # degrees or radians
+        try:
+            if not mla.check(""):
+                raise ValueError(
+                    "MLA must be a Quantity with a dimensionality of '' (ie. nothing)"
+                )
+            if not (
+                mla.units == unit_registry.degree or mla.units == unit_registry.radian
+            ):
+                raise ValueError(
+                    "MLA must be a Quantity with angular units (degree or radian)"
+                )
+        except AttributeError:
+            raise TypeError("MLA must be a Quantity")
+
+        # Set the actual bearing attribute to the given value converted to radians
+        self._mla = mla.to(unit_registry.radian).magnitude
+
+    @mla.expression
+    def mla(self):
+        return self._mla
+
 
 class CommentMixin:
     def submit(self, data_store, change_id):

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -410,6 +410,48 @@ class ContactMixin:
     def bearing(self):
         return self._bearing
 
+    #
+    # Rel Bearing properties
+    #
+
+    @hybrid_property
+    def rel_bearing(self):
+        # Return all rel_bearings as degrees
+        if self._rel_bearing is None:
+            return None
+        else:
+            return (self._rel_bearing * unit_registry.radian).to(unit_registry.degree)
+
+    @rel_bearing.setter
+    def rel_bearing(self, rel_bearing):
+        if rel_bearing is None:
+            self._rel_bearing = None
+            return
+
+        # Check the given bearing is a Quantity with a dimension of '' and units of
+        # degrees or radians
+        try:
+            if not rel_bearing.check(""):
+                raise ValueError(
+                    "Relative Bearing must be a Quantity with a dimensionality of '' (ie. nothing)"
+                )
+            if not (
+                rel_bearing.units == unit_registry.degree
+                or rel_bearing.units == unit_registry.radian
+            ):
+                raise ValueError(
+                    "Relative Bearing must be a Quantity with angular units (degree or radian)"
+                )
+        except AttributeError:
+            raise TypeError("Relative Bearing must be a Quantity")
+
+        # Set the actual bearing attribute to the given value converted to radians
+        self._rel_bearing = rel_bearing.to(unit_registry.radian).magnitude
+
+    @rel_bearing.expression
+    def rel_bearing(self):
+        return self._rel_bearing
+
 
 class CommentMixin:
     def submit(self, data_store, change_id):

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -572,6 +572,40 @@ class ContactMixin:
     def orientation(self):
         return self._orientation
 
+    #
+    # Major property
+    #
+
+    @hybrid_property
+    def major(self):
+        # Return all majors as metres
+        if self._major is None:
+            return None
+        else:
+            return self._major * unit_registry.metre
+
+    @major.setter
+    def major(self, major):
+        if major is None:
+            self._major = None
+            return
+
+        # Check the given major is a Quantity with a dimension of 'length'
+        try:
+            if not major.check("[length]"):
+                raise ValueError(
+                    "Major must be a Quantity with a dimensionality of [length]"
+                )
+        except AttributeError:
+            raise TypeError("Major must be a Quantity")
+
+        # Set the actual major attribute to the given value converted to metres
+        self._major = major.to(unit_registry.metre).magnitude
+
+    @major.expression
+    def major(self):
+        return self._major
+
 
 class CommentMixin:
     def submit(self, data_store, change_id):

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -641,6 +641,40 @@ class ContactMixin:
         return self._minor
 
     #
+    # Range property
+    #
+
+    @hybrid_property
+    def range(self):
+        # Return all ranges as metres
+        if self._range is None:
+            return None
+        else:
+            return self._range * unit_registry.metre
+
+    @range.setter
+    def range(self, range):
+        if range is None:
+            self._range = None
+            return
+
+        # Check the given range is a Quantity with a dimension of 'length'
+        try:
+            if not range.check("[length]"):
+                raise ValueError(
+                    "Range must be a Quantity with a dimensionality of [length]"
+                )
+        except AttributeError:
+            raise TypeError("Range must be a Quantity")
+
+        # Set the actual range attribute to the given value converted to metres
+        self._range = range.to(unit_registry.metre).magnitude
+
+    @range.expression
+    def range(self):
+        return self._range
+
+    #
     # Freq property
     #
 

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -1329,18 +1329,19 @@ class DataStore(object):
             except Exception as ex:
                 print(str(ex))
 
-            # wkb hex conversion to "point"
-            point = None
-            if contact.location is not None:
-                point = wkb.loads(contact.location.desc, hex=True)
-
             contact_rep_line = [
                 transformer.format_datatime(contact.time),
                 platform_name,
                 "@@",
-                transformer.format_point(point.y, point.x) if point else "NULL",
-                str(math.degrees(contact.bearing)) if contact.bearing else "NULL",
-                "NULL",  # unit_converter.convert_meter_to_yard(contact.range) if contact.range else "NULL",
+                transformer.format_point(
+                    state.location.longitude, state.location.latitude
+                )
+                if state.location
+                else "NULL",
+                contact.bearing.to(unit_registry.degrees).magnitude
+                if contact.bearing
+                else "NULL",
+                contact.range.to(unit_registry.yard) if contact.range else "NULL",
                 sensor_name,
                 "N/A",
             ]

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -1304,12 +1304,8 @@ class DataStore(object):
                 transformer.format_point(
                     state.location.longitude, state.location.latitude
                 ),
-                str(unit_converter.convert_radian_to_degree(state.heading))
-                if state.heading
-                else "0",
-                str(unit_converter.convert_mps_to_knot(state.speed))
-                if state.speed
-                else "0",
+                str(state.heading.to(unit_registry.degrees)) if state.heading else "0",
+                str(state.speed.to(unit_registry.knot)) if state.speed else "0",
                 depthStr,
             ]
             data = " ".join(state_rep_line)

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -472,7 +472,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropert
     _location = Column(Geometry(geometry_type="POINT", srid=4326))
     _elevation = Column(DOUBLE_PRECISION)
     _major = Column(DOUBLE_PRECISION)
-    minor = Column(DOUBLE_PRECISION)
+    _minor = Column(DOUBLE_PRECISION)
     _orientation = Column(DOUBLE_PRECISION)
     classification = Column(String(150))
     confidence = Column(String(150))

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -466,7 +466,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin):
         UUID(as_uuid=True), ForeignKey("pepys.Sensors.sensor_id"), nullable=False
     )
     time = Column(TIMESTAMP, nullable=False)
-    bearing = Column(DOUBLE_PRECISION)
+    _bearing = Column(DOUBLE_PRECISION)
     rel_bearing = Column(DOUBLE_PRECISION)
     freq = Column(DOUBLE_PRECISION)
     _location = Column(Geometry(geometry_type="POINT", srid=4326))

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -478,7 +478,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin):
     confidence = Column(String(150))
     contact_type = Column(String(150))
     _mla = Column(DOUBLE_PRECISION)
-    sla = Column(DOUBLE_PRECISION)
+    _sla = Column(DOUBLE_PRECISION)
     subject_id = Column(UUID(as_uuid=True), ForeignKey("pepys.Platforms.platform_id"))
     source_id = Column(
         UUID(as_uuid=True), ForeignKey("pepys.Datafiles.datafile_id"), nullable=False

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -471,7 +471,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropert
     freq = Column(DOUBLE_PRECISION)
     _location = Column(Geometry(geometry_type="POINT", srid=4326))
     _elevation = Column(DOUBLE_PRECISION)
-    major = Column(DOUBLE_PRECISION)
+    _major = Column(DOUBLE_PRECISION)
     minor = Column(DOUBLE_PRECISION)
     _orientation = Column(DOUBLE_PRECISION)
     classification = Column(String(150))

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -469,6 +469,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropert
     _bearing = Column(DOUBLE_PRECISION)
     _rel_bearing = Column(DOUBLE_PRECISION)
     _freq = Column(DOUBLE_PRECISION)
+    _range = Column(DOUBLE_PRECISION)
     _location = Column(Geometry(geometry_type="POINT", srid=4326))
     _elevation = Column(DOUBLE_PRECISION)
     _major = Column(DOUBLE_PRECISION)

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -467,7 +467,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin):
     )
     time = Column(TIMESTAMP, nullable=False)
     _bearing = Column(DOUBLE_PRECISION)
-    rel_bearing = Column(DOUBLE_PRECISION)
+    _rel_bearing = Column(DOUBLE_PRECISION)
     freq = Column(DOUBLE_PRECISION)
     _location = Column(Geometry(geometry_type="POINT", srid=4326))
     elevation = Column(DOUBLE_PRECISION)

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -473,7 +473,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropert
     _elevation = Column(DOUBLE_PRECISION)
     major = Column(DOUBLE_PRECISION)
     minor = Column(DOUBLE_PRECISION)
-    orientation = Column(DOUBLE_PRECISION)
+    _orientation = Column(DOUBLE_PRECISION)
     classification = Column(String(150))
     confidence = Column(String(150))
     contact_type = Column(String(150))

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -477,7 +477,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin):
     classification = Column(String(150))
     confidence = Column(String(150))
     contact_type = Column(String(150))
-    mla = Column(DOUBLE_PRECISION)
+    _mla = Column(DOUBLE_PRECISION)
     sla = Column(DOUBLE_PRECISION)
     subject_id = Column(UUID(as_uuid=True), ForeignKey("pepys.Platforms.platform_id"))
     source_id = Column(

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -449,7 +449,7 @@ class State(BasePostGIS, StateMixin, ElevationPropertyMixin, LocationPropertyMix
     created_date = Column(DateTime, default=datetime.utcnow)
 
 
-class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin):
+class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropertyMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.sensor_name = None
@@ -470,7 +470,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin):
     _rel_bearing = Column(DOUBLE_PRECISION)
     freq = Column(DOUBLE_PRECISION)
     _location = Column(Geometry(geometry_type="POINT", srid=4326))
-    elevation = Column(DOUBLE_PRECISION)
+    _elevation = Column(DOUBLE_PRECISION)
     major = Column(DOUBLE_PRECISION)
     minor = Column(DOUBLE_PRECISION)
     orientation = Column(DOUBLE_PRECISION)

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -468,7 +468,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropert
     time = Column(TIMESTAMP, nullable=False)
     _bearing = Column(DOUBLE_PRECISION)
     _rel_bearing = Column(DOUBLE_PRECISION)
-    freq = Column(DOUBLE_PRECISION)
+    _freq = Column(DOUBLE_PRECISION)
     _location = Column(Geometry(geometry_type="POINT", srid=4326))
     _elevation = Column(DOUBLE_PRECISION)
     _major = Column(DOUBLE_PRECISION)

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -382,7 +382,7 @@ class Contact(BaseSpatiaLite, ContactMixin, LocationPropertyMixin):
     name = Column(String(150))
     sensor_id = Column(Integer, nullable=False)
     time = Column(TIMESTAMP, nullable=False)
-    bearing = Column(REAL)
+    _bearing = Column(REAL)
     rel_bearing = Column(REAL)
     freq = Column(REAL)
     _location = Column(Geometry(geometry_type="POINT", srid=4326, management=True))

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -393,7 +393,7 @@ class Contact(BaseSpatiaLite, ContactMixin, LocationPropertyMixin):
     classification = Column(String(150))
     confidence = Column(String(150))
     contact_type = Column(String(150))
-    mla = Column(REAL)
+    _mla = Column(REAL)
     sla = Column(REAL)
     subject_id = Column(Integer)
     source_id = Column(Integer, nullable=False)

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -394,7 +394,7 @@ class Contact(BaseSpatiaLite, ContactMixin, LocationPropertyMixin):
     confidence = Column(String(150))
     contact_type = Column(String(150))
     _mla = Column(REAL)
-    sla = Column(REAL)
+    _sla = Column(REAL)
     subject_id = Column(Integer)
     source_id = Column(Integer, nullable=False)
     privacy_id = Column(Integer)

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -391,7 +391,7 @@ class Contact(
     _elevation = Column(REAL)
     major = Column(REAL)
     minor = Column(REAL)
-    orientation = Column(REAL)
+    _orientation = Column(REAL)
     classification = Column(String(150))
     confidence = Column(String(150))
     contact_type = Column(String(150))

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -389,7 +389,7 @@ class Contact(
     freq = Column(REAL)
     _location = Column(Geometry(geometry_type="POINT", srid=4326, management=True))
     _elevation = Column(REAL)
-    major = Column(REAL)
+    _major = Column(REAL)
     minor = Column(REAL)
     _orientation = Column(REAL)
     classification = Column(String(150))

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -383,7 +383,7 @@ class Contact(BaseSpatiaLite, ContactMixin, LocationPropertyMixin):
     sensor_id = Column(Integer, nullable=False)
     time = Column(TIMESTAMP, nullable=False)
     _bearing = Column(REAL)
-    rel_bearing = Column(REAL)
+    _rel_bearing = Column(REAL)
     freq = Column(REAL)
     _location = Column(Geometry(geometry_type="POINT", srid=4326, management=True))
     elevation = Column(REAL)

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -387,6 +387,7 @@ class Contact(
     _bearing = Column(REAL)
     _rel_bearing = Column(REAL)
     _freq = Column(REAL)
+    _range = Column(REAL)
     _location = Column(Geometry(geometry_type="POINT", srid=4326, management=True))
     _elevation = Column(REAL)
     _major = Column(REAL)

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -368,7 +368,9 @@ class State(BaseSpatiaLite, StateMixin, ElevationPropertyMixin, LocationProperty
     created_date = Column(DateTime, default=datetime.utcnow)
 
 
-class Contact(BaseSpatiaLite, ContactMixin, LocationPropertyMixin):
+class Contact(
+    BaseSpatiaLite, ContactMixin, LocationPropertyMixin, ElevationPropertyMixin
+):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.sensor_name = None
@@ -386,7 +388,7 @@ class Contact(BaseSpatiaLite, ContactMixin, LocationPropertyMixin):
     _rel_bearing = Column(REAL)
     freq = Column(REAL)
     _location = Column(Geometry(geometry_type="POINT", srid=4326, management=True))
-    elevation = Column(REAL)
+    _elevation = Column(REAL)
     major = Column(REAL)
     minor = Column(REAL)
     orientation = Column(REAL)

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -386,7 +386,7 @@ class Contact(
     time = Column(TIMESTAMP, nullable=False)
     _bearing = Column(REAL)
     _rel_bearing = Column(REAL)
-    freq = Column(REAL)
+    _freq = Column(REAL)
     _location = Column(Geometry(geometry_type="POINT", srid=4326, management=True))
     _elevation = Column(REAL)
     _major = Column(REAL)

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -390,7 +390,7 @@ class Contact(
     _location = Column(Geometry(geometry_type="POINT", srid=4326, management=True))
     _elevation = Column(REAL)
     _major = Column(REAL)
-    minor = Column(REAL)
+    _minor = Column(REAL)
     _orientation = Column(REAL)
     classification = Column(String(150))
     confidence = Column(String(150))

--- a/pepys_import/utils/unit_utils.py
+++ b/pepys_import/utils/unit_utils.py
@@ -181,15 +181,3 @@ def convert_distance(distance, units, line_number, errors, error_type):
         return False
     distance = valid_distance * units
     return distance
-
-
-def convert_radian_to_degree(radian_value):
-    return (radian_value * unit_registry.radians).to(unit_registry.degree).magnitude
-
-
-def convert_meter_to_yard(meters):
-    return (meters * unit_registry.meter).to(unit_registry.yard).magnitude
-
-
-def convert_mps_to_knot(mps_value):
-    return round(mps_value.to(unit_registry.knot).magnitude, 3,)

--- a/pepys_import/utils/unit_utils.py
+++ b/pepys_import/utils/unit_utils.py
@@ -121,9 +121,42 @@ def distance_between_two_points_haversine(first_location, second_location):
     )
 
 
+def convert_frequency(frequency, units, line_number, errors, error_type):
+    """
+    Converts the given frequency string to a Quantity containing a float
+    value and the given units
+
+    :param frequency: frequency value in string format
+    :type frequency: String
+    :param units: units of frequency for supplied measurement
+    :type units: String
+    :param line_number: Line number
+    :type line_number: String
+    :param errors: Error List to save value error if it raises
+    :type errors: List
+    :param error_type: Type of error
+    :type error_type: String
+    :return: return the converted speed value
+    """
+    try:
+        valid_frequency = float(frequency)
+    except ValueError:
+        errors.append(
+            {
+                error_type: f"Line {line_number}. Error in frequency value {frequency}. "
+                f"Couldn't convert to a number"
+            }
+        )
+        return False
+    frequency = valid_frequency * units
+    return frequency
+
+
 def convert_distance(distance, units, line_number, errors, error_type):
     """
-    Converts the given distance value in supplied units to metres formsat
+    Converts the given distance string to a Quantity consisting of a
+    float value and the given units.
+    
     :param distance: distance value in string format
     :type distance: String
     :param units: units of distance for supplied measurement
@@ -146,7 +179,7 @@ def convert_distance(distance, units, line_number, errors, error_type):
             }
         )
         return False
-    distance = (valid_distance * units).to(unit_registry.meter).magnitude
+    distance = valid_distance * units
     return distance
 
 

--- a/tests/test_load_rep_contact.py
+++ b/tests/test_load_rep_contact.py
@@ -69,7 +69,7 @@ class RepContactTests(unittest.TestCase):
             self.assertEqual(contacts[0].location, None)
             self.assertEqual(contacts[3].location, None)
 
-            # todo, also test that the correct range is being stored
+            self.assertAlmostEqual(contacts[0].range, 395.11224 * unit_registry.metre)
 
             # Check location point's type and value
             location1 = contacts[1].location

--- a/tests/test_load_rep_contact.py
+++ b/tests/test_load_rep_contact.py
@@ -9,6 +9,8 @@ from importers.replay_contact_importer import ReplayContactImporter
 from pepys_import.file.file_processor import FileProcessor
 from pepys_import.core.store.data_store import DataStore
 from pepys_import.core.formats.location import Location
+from pepys_import.core.formats import unit_registry
+
 
 FILE_PATH = os.path.dirname(__file__)
 DATA_PATH1 = os.path.join(FILE_PATH, "sample_data/track_files/rep_data/rep_test1.rep")
@@ -56,10 +58,13 @@ class RepContactTests(unittest.TestCase):
             self.assertEqual(len(contacts), 7)
 
             # check the data contents
-            self.assertEqual(contacts[0].bearing, math.radians(252.85))
-            self.assertEqual(contacts[1].bearing, math.radians(251.33))
+            self.assertEqual(contacts[0].bearing, 252.85 * unit_registry.degree)
 
-            self.assertEqual(contacts[0].freq, 123.4)
+            # Has to be almost equal as we get a number very slightly different to 251.33
+            # due to floating point precision issues
+            self.assertAlmostEqual(contacts[1].bearing, 251.33 * unit_registry.degree)
+
+            self.assertEqual(contacts[0].freq, 123.4 * unit_registry.hertz)
 
             self.assertEqual(contacts[0].location, None)
             self.assertEqual(contacts[3].location, None)
@@ -116,8 +121,8 @@ class RepContactTests(unittest.TestCase):
             self.assertEqual(len(contacts), 95)
 
             # check the data contents
-            self.assertEqual(contacts[0].bearing, math.radians(80))
-            self.assertEqual(contacts[1].bearing, math.radians(78))
+            self.assertEqual(contacts[0].bearing, 80 * unit_registry.degree)
+            self.assertEqual(contacts[1].bearing, 78 * unit_registry.degree)
 
             self.assertEqual(contacts[0].location, None)
             self.assertEqual(contacts[3].location, None)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -342,6 +342,53 @@ class TestContactRelBearingProperty(unittest.TestCase):
         assert contact.rel_bearing.check("")
 
 
+class TestContactMLAProperty(unittest.TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_contact_mla_scalar(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            contact.mla = 5
+
+        assert "MLA must be a Quantity" in str(exception.value)
+
+    def test_contact_mla_wrong_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            contact.mla = 5 * unit_registry.second
+
+        assert "MLA must be a Quantity with a dimensionality of ''" in str(
+            exception.value
+        )
+
+    def test_contact_mla_right_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the right SI units succeeds
+        contact.mla = 57 * unit_registry.degree
+
+        # Check setting with a Quantity of strange but valid units succeeds
+        contact.mla = 0.784 * unit_registry.radian
+
+    def test_contact_mla_roundtrip(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting and retrieving field works, and gives units as a result
+        contact.mla = 157 * unit_registry.degree
+
+        assert contact.mla == 157 * unit_registry.degree
+        assert contact.mla.check("")
+
+
 CLASSES_WITH_LOCATION = [
     pytest.param("State", id="state"),
     pytest.param("Media", id="media"),

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -436,6 +436,53 @@ class TestContactMajorProperty(unittest.TestCase):
         assert contact.major.check("[length]")
 
 
+class TestContactMinorProperty(unittest.TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_contact_minor_scalar(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            contact.minor = 5
+
+        assert "Minor must be a Quantity" in str(exception.value)
+
+    def test_contact_minor_wrong_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            contact.minor = 5 * unit_registry.second
+
+        assert "Minor must be a Quantity with a dimensionality of [length]" in str(
+            exception.value
+        )
+
+    def test_contact_minor_right_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the right SI units succeeds
+        contact.minor = 32 * unit_registry.kilometre
+
+        # Check setting with a Quantity of strange but valid units succeeds
+        contact.minor = 1943 * unit_registry.angstrom
+
+    def test_contact_minor_roundtrip(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting and retrieving field works, and gives units as a result
+        contact.minor = 1023 * unit_registry.metre
+
+        assert contact.minor == 1023 * unit_registry.metre
+        assert contact.minor.check("[length]")
+
+
 CLASSES_WITH_ELEVATION = [
     pytest.param("State", id="state"),
     pytest.param("Media", id="media"),

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -389,6 +389,53 @@ class TestContactOrientationProperty(unittest.TestCase):
         assert contact.orientation.check("")
 
 
+class TestContactMajorProperty(unittest.TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_contact_major_scalar(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            contact.major = 5
+
+        assert "Major must be a Quantity" in str(exception.value)
+
+    def test_contact_major_wrong_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            contact.major = 5 * unit_registry.second
+
+        assert "Major must be a Quantity with a dimensionality of [length]" in str(
+            exception.value
+        )
+
+    def test_contact_major_right_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the right SI units succeeds
+        contact.major = 57 * unit_registry.kilometre
+
+        # Check setting with a Quantity of strange but valid units succeeds
+        contact.major = 1523 * unit_registry.angstrom
+
+    def test_contact_major_roundtrip(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting and retrieving field works, and gives units as a result
+        contact.major = 1234 * unit_registry.metre
+
+        assert contact.major == 1234 * unit_registry.metre
+        assert contact.major.check("[length]")
+
+
 CLASSES_WITH_ELEVATION = [
     pytest.param("State", id="state"),
     pytest.param("Media", id="media"),

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -342,6 +342,53 @@ class TestContactSLAProperty(unittest.TestCase):
         assert contact.sla.check("")
 
 
+class TestContactOrientationProperty(unittest.TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_contact_orientation_scalar(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            contact.orientation = 5
+
+        assert "Orientation must be a Quantity" in str(exception.value)
+
+    def test_contact_orientation_wrong_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            contact.orientation = 5 * unit_registry.second
+
+        assert "Orientation must be a Quantity with a dimensionality of ''" in str(
+            exception.value
+        )
+
+    def test_contact_orientation_right_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the right SI units succeeds
+        contact.orientation = 57 * unit_registry.degree
+
+        # Check setting with a Quantity of strange but valid units succeeds
+        contact.orientation = 0.784 * unit_registry.radian
+
+    def test_contact_orientation_roundtrip(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting and retrieving field works, and gives units as a result
+        contact.orientation = 53 * unit_registry.degree
+
+        assert contact.orientation == 53 * unit_registry.degree
+        assert contact.orientation.check("")
+
+
 CLASSES_WITH_ELEVATION = [
     pytest.param("State", id="state"),
     pytest.param("Media", id="media"),

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -248,9 +248,57 @@ class TestMediaElevationProperty(unittest.TestCase):
         assert media.elevation.check("[length]")
 
 
+class TestContactBearingProperty(unittest.TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_contact_bearing_scalar(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            contact.bearing = 5
+
+        assert "Bearing must be a Quantity" in str(exception.value)
+
+    def test_contact_bearing_wrong_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            contact.bearing = 5 * unit_registry.second
+
+        assert "Bearing must be a Quantity with a dimensionality of ''" in str(
+            exception.value
+        )
+
+    def test_contact_bearing_right_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the right SI units succeeds
+        contact.bearing = 57 * unit_registry.degree
+
+        # Check setting with a Quantity of strange but valid units succeeds
+        contact.bearing = 0.784 * unit_registry.radian
+
+    def test_contact_bearing_roundtrip(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting and retrieving field works, and gives units as a result
+        contact.heading = 157 * unit_registry.degree
+
+        assert contact.heading == 157 * unit_registry.degree
+        assert contact.heading.check("")
+
+
 CLASSES_WITH_LOCATION = [
     pytest.param("State", id="state"),
     pytest.param("Media", id="media"),
+    pytest.param("Contact", id="contact"),
 ]
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -20,6 +20,13 @@ class TestStateSpeedProperty(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_state_speed_none(self):
+        state = self.store.db_classes.State()
+
+        state.speed = None
+
+        assert state.speed is None
+
     def test_state_speed_scalar(self):
         state = self.store.db_classes.State()
 
@@ -68,6 +75,13 @@ class TestStateHeadingProperty(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_state_heading_none(self):
+        state = self.store.db_classes.State()
+
+        state.heading = None
+
+        assert state.heading is None
+
     def test_state_heading_scalar(self):
         state = self.store.db_classes.State()
 
@@ -114,6 +128,13 @@ class TestStateCourseProperty(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    def test_state_course_none(self):
+        state = self.store.db_classes.State()
+
+        state.course = None
+
+        assert state.course is None
 
     def test_state_course_scalar(self):
         state = self.store.db_classes.State()
@@ -162,6 +183,13 @@ class TestContactBearingProperty(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_contact_bearing_none(self):
+        contact = self.store.db_classes.Contact()
+
+        contact.bearing = None
+
+        assert contact.bearing is None
+
     def test_contact_bearing_scalar(self):
         contact = self.store.db_classes.Contact()
 
@@ -208,6 +236,13 @@ class TestContactRelBearingProperty(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    def test_contact_rel_bearing_none(self):
+        contact = self.store.db_classes.Contact()
+
+        contact.rel_bearing = None
+
+        assert contact.rel_bearing is None
 
     def test_contact_rel_bearing_scalar(self):
         contact = self.store.db_classes.Contact()
@@ -256,6 +291,13 @@ class TestContactMLAProperty(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_contact_mla_none(self):
+        contact = self.store.db_classes.Contact()
+
+        contact.mla = None
+
+        assert contact.mla is None
+
     def test_contact_mla_scalar(self):
         contact = self.store.db_classes.Contact()
 
@@ -302,6 +344,13 @@ class TestContactSLAProperty(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    def test_contact_sla_none(self):
+        contact = self.store.db_classes.Contact()
+
+        contact.sla = None
+
+        assert contact.sla is None
 
     def test_contact_sla_scalar(self):
         contact = self.store.db_classes.Contact()
@@ -350,6 +399,13 @@ class TestContactOrientationProperty(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_contact_orientation_none(self):
+        contact = self.store.db_classes.Contact()
+
+        contact.orientation = None
+
+        assert contact.orientation is None
+
     def test_contact_orientation_scalar(self):
         contact = self.store.db_classes.Contact()
 
@@ -396,6 +452,13 @@ class TestContactMajorProperty(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    def test_contact_major_none(self):
+        contact = self.store.db_classes.Contact()
+
+        contact.major = None
+
+        assert contact.major is None
 
     def test_contact_major_scalar(self):
         contact = self.store.db_classes.Contact()
@@ -444,6 +507,13 @@ class TestContactMinorProperty(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_contact_minor_none(self):
+        contact = self.store.db_classes.Contact()
+
+        contact.minor = None
+
+        assert contact.minor is None
+
     def test_contact_minor_scalar(self):
         contact = self.store.db_classes.Contact()
 
@@ -491,6 +561,13 @@ class TestContactRangeProperty(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_contact_range_none(self):
+        contact = self.store.db_classes.Contact()
+
+        contact.range = None
+
+        assert contact.range is None
+
     def test_contact_range_scalar(self):
         contact = self.store.db_classes.Contact()
 
@@ -537,6 +614,13 @@ class TestContactFreqProperty(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    def test_contact_freq_none(self):
+        contact = self.store.db_classes.Contact()
+
+        contact.freq = None
+
+        assert contact.freq is None
 
     def test_contact_freq_scalar(self):
         contact = self.store.db_classes.Contact()
@@ -588,6 +672,16 @@ class TestElevationProperty:
 
     def tearDown(self):
         pass
+
+    @pytest.mark.parametrize(
+        "class_name", CLASSES_WITH_ELEVATION,
+    )
+    def test_elevation_none(self, class_name):
+        obj = eval(f"self.store.db_classes.{class_name}()")
+
+        obj.elevation = None
+
+        assert obj.elevation is None
 
     @pytest.mark.parametrize(
         "class_name", CLASSES_WITH_ELEVATION,
@@ -654,6 +748,16 @@ class TestLocationProperty:
 
     def tearDown(self):
         pass
+
+    @pytest.mark.parametrize(
+        "class_name", CLASSES_WITH_LOCATION,
+    )
+    def test_location_property_none(self, class_name):
+        obj = eval(f"self.store.db_classes.{class_name}()")
+
+        obj.location = None
+
+        assert obj.location is None
 
     @pytest.mark.parametrize(
         "class_name", CLASSES_WITH_LOCATION,

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -383,10 +383,57 @@ class TestContactMLAProperty(unittest.TestCase):
         contact = self.store.db_classes.Contact()
 
         # Check setting and retrieving field works, and gives units as a result
-        contact.mla = 157 * unit_registry.degree
+        contact.mla = 234 * unit_registry.degree
 
-        assert contact.mla == 157 * unit_registry.degree
+        assert contact.mla == 234 * unit_registry.degree
         assert contact.mla.check("")
+
+
+class TestContactSLAProperty(unittest.TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_contact_sla_scalar(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            contact.sla = 5
+
+        assert "SLA must be a Quantity" in str(exception.value)
+
+    def test_contact_sla_wrong_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            contact.sla = 5 * unit_registry.second
+
+        assert "SLA must be a Quantity with a dimensionality of ''" in str(
+            exception.value
+        )
+
+    def test_contact_sla_right_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the right SI units succeeds
+        contact.sla = 57 * unit_registry.degree
+
+        # Check setting with a Quantity of strange but valid units succeeds
+        contact.sla = 0.784 * unit_registry.radian
+
+    def test_contact_sla_roundtrip(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting and retrieving field works, and gives units as a result
+        contact.sla = 198 * unit_registry.degree
+
+        assert contact.sla == 198 * unit_registry.degree
+        assert contact.sla.check("")
 
 
 CLASSES_WITH_LOCATION = [

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -289,10 +289,57 @@ class TestContactBearingProperty(unittest.TestCase):
         contact = self.store.db_classes.Contact()
 
         # Check setting and retrieving field works, and gives units as a result
-        contact.heading = 157 * unit_registry.degree
+        contact.bearing = 157 * unit_registry.degree
 
-        assert contact.heading == 157 * unit_registry.degree
-        assert contact.heading.check("")
+        assert contact.bearing == 157 * unit_registry.degree
+        assert contact.bearing.check("")
+
+
+class TestContactRelBearingProperty(unittest.TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_contact_rel_bearing_scalar(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            contact.rel_bearing = 5
+
+        assert "Relative Bearing must be a Quantity" in str(exception.value)
+
+    def test_contact_rel_bearing_wrong_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            contact.rel_bearing = 5 * unit_registry.second
+
+        assert "Relative Bearing must be a Quantity with a dimensionality of ''" in str(
+            exception.value
+        )
+
+    def test_contact_rel_bearing_right_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the right SI units succeeds
+        contact.rel_bearing = 57 * unit_registry.degree
+
+        # Check setting with a Quantity of strange but valid units succeeds
+        contact.rel_bearing = 0.784 * unit_registry.radian
+
+    def test_contact_rel_bearing_roundtrip(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting and retrieving field works, and gives units as a result
+        contact.rel_bearing = 157 * unit_registry.degree
+
+        assert contact.rel_bearing == 157 * unit_registry.degree
+        assert contact.rel_bearing.check("")
 
 
 CLASSES_WITH_LOCATION = [

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -60,53 +60,6 @@ class TestStateSpeedProperty(unittest.TestCase):
         assert state.speed.check("[length]/[time]")
 
 
-class TestStateElevationProperty(unittest.TestCase):
-    def setUp(self):
-        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
-        self.store.initialise()
-
-    def tearDown(self):
-        pass
-
-    def test_state_elevation_scalar(self):
-        state = self.store.db_classes.State()
-
-        # Check setting with a scalar (float) gives error
-        with pytest.raises(TypeError) as exception:
-            state.elevation = 5
-
-        assert "Elevation must be a Quantity" in str(exception.value)
-
-    def test_state_elevation_wrong_units(self):
-        state = self.store.db_classes.State()
-
-        # Check setting with a Quantity of the wrong units gives error
-        with pytest.raises(ValueError) as exception:
-            state.elevation = 5 * unit_registry.second
-
-        assert "Elevation must be a Quantity with a dimensionality of [length]" in str(
-            exception.value
-        )
-
-    def test_state_elevation_right_units(self):
-        state = self.store.db_classes.State()
-
-        # Check setting with a Quantity of the right SI units succeeds
-        state.elevation = 5 * unit_registry.metre
-
-        # Check setting with a Quantity of strange but valid units succeeds
-        state.elevation = 5 * unit_registry.angstrom
-
-    def test_state_elevation_roundtrip(self):
-        state = self.store.db_classes.State()
-
-        # Check setting and retrieving field works, and gives units as a result
-        state.elevation = 10 * unit_registry.metre
-
-        assert state.elevation == 10 * unit_registry.metre
-        assert state.elevation.check("[length]")
-
-
 class TestStateHeadingProperty(unittest.TestCase):
     def setUp(self):
         self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
@@ -199,53 +152,6 @@ class TestStateCourseProperty(unittest.TestCase):
 
         assert state.course == 157 * unit_registry.degree
         assert state.course.check("")
-
-
-class TestMediaElevationProperty(unittest.TestCase):
-    def setUp(self):
-        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
-        self.store.initialise()
-
-    def tearDown(self):
-        pass
-
-    def test_media_elevation_scalar(self):
-        media = self.store.db_classes.Media()
-
-        # Check setting with a scalar (float) gives error
-        with pytest.raises(TypeError) as exception:
-            media.elevation = 5
-
-        assert "Elevation must be a Quantity" in str(exception.value)
-
-    def test_media_elevation_wrong_units(self):
-        media = self.store.db_classes.Media()
-
-        # Check setting with a Quantity of the wrong units gives error
-        with pytest.raises(ValueError) as exception:
-            media.elevation = 5 * unit_registry.second
-
-        assert "Elevation must be a Quantity with a dimensionality of [length]" in str(
-            exception.value
-        )
-
-    def test_media_elevation_right_units(self):
-        media = self.store.db_classes.Media()
-
-        # Check setting with a Quantity of the right SI units succeeds
-        media.elevation = 5 * unit_registry.metre
-
-        # Check setting with a Quantity of strange but valid units succeeds
-        media.elevation = 5 * unit_registry.angstrom
-
-    def test_media_elevation_roundtrip(self):
-        media = self.store.db_classes.Media()
-
-        # Check setting and retrieving field works, and gives units as a result
-        media.elevation = 10 * unit_registry.metre
-
-        assert media.elevation == 10 * unit_registry.metre
-        assert media.elevation.check("[length]")
 
 
 class TestContactBearingProperty(unittest.TestCase):
@@ -436,6 +342,72 @@ class TestContactSLAProperty(unittest.TestCase):
         assert contact.sla.check("")
 
 
+CLASSES_WITH_ELEVATION = [
+    pytest.param("State", id="state"),
+    pytest.param("Media", id="media"),
+    pytest.param("Contact", id="contact"),
+]
+
+
+class TestElevationProperty:
+    def setup_class(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    @pytest.mark.parametrize(
+        "class_name", CLASSES_WITH_ELEVATION,
+    )
+    def test_elevation_scalar(self, class_name):
+        obj = eval(f"self.store.db_classes.{class_name}()")
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            obj.elevation = 5
+
+        assert "Elevation must be a Quantity" in str(exception.value)
+
+    @pytest.mark.parametrize(
+        "class_name", CLASSES_WITH_ELEVATION,
+    )
+    def test_elevation_wrong_units(self, class_name):
+        obj = eval(f"self.store.db_classes.{class_name}()")
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            obj.elevation = 5 * unit_registry.second
+
+        assert "Elevation must be a Quantity with a dimensionality of [length]" in str(
+            exception.value
+        )
+
+    @pytest.mark.parametrize(
+        "class_name", CLASSES_WITH_ELEVATION,
+    )
+    def test_elevation_right_units(self, class_name):
+        obj = eval(f"self.store.db_classes.{class_name}()")
+
+        # Check setting with a Quantity of the right SI units succeeds
+        obj.elevation = 5 * unit_registry.metre
+
+        # Check setting with a Quantity of strange but valid units succeeds
+        obj.elevation = 5 * unit_registry.angstrom
+
+    @pytest.mark.parametrize(
+        "class_name", CLASSES_WITH_ELEVATION,
+    )
+    def test_state_elevation_roundtrip(self, class_name):
+        obj = eval(f"self.store.db_classes.{class_name}()")
+
+        # Check setting and retrieving field works, and gives units as a result
+        obj.elevation = 10 * unit_registry.metre
+
+        assert obj.elevation == 10 * unit_registry.metre
+        assert obj.elevation.check("[length]")
+
+
 CLASSES_WITH_LOCATION = [
     pytest.param("State", id="state"),
     pytest.param("Media", id="media"),
@@ -456,7 +428,6 @@ class TestLocationProperty:
     )
     def test_location_property_invalid_type(self, class_name):
         obj = eval(f"self.store.db_classes.{class_name}()")
-        print(type(obj))
         with pytest.raises(TypeError) as exception:
             obj.location = (50, -1)
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -483,6 +483,53 @@ class TestContactMinorProperty(unittest.TestCase):
         assert contact.minor.check("[length]")
 
 
+class TestContactRangeProperty(unittest.TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_contact_range_scalar(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            contact.range = 5
+
+        assert "Range must be a Quantity" in str(exception.value)
+
+    def test_contact_range_wrong_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            contact.range = 5 * unit_registry.second
+
+        assert "Range must be a Quantity with a dimensionality of [length]" in str(
+            exception.value
+        )
+
+    def test_contact_range_right_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the right SI units succeeds
+        contact.range = 19 * unit_registry.yard
+
+        # Check setting with a Quantity of strange but valid units succeeds
+        contact.range = 2341 * unit_registry.angstrom
+
+    def test_contact_range_roundtrip(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting and retrieving field works, and gives units as a result
+        contact.range = 976 * unit_registry.metre
+
+        assert contact.range == 976 * unit_registry.metre
+        assert contact.range.check("[length]")
+
+
 class TestContactFreqProperty(unittest.TestCase):
     def setUp(self):
         self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -483,6 +483,50 @@ class TestContactMinorProperty(unittest.TestCase):
         assert contact.minor.check("[length]")
 
 
+class TestContactFreqProperty(unittest.TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_contact_freq_scalar(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a scalar (float) gives error
+        with pytest.raises(TypeError) as exception:
+            contact.freq = 5
+
+        assert "Freq must be a Quantity" in str(exception.value)
+
+    def test_contact_freq_wrong_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the wrong units gives error
+        with pytest.raises(ValueError) as exception:
+            contact.freq = 5 * unit_registry.kilogram
+
+        assert "Freq must be a Quantity with a dimensionality of [time]^-1" in str(
+            exception.value
+        )
+
+    def test_contact_freq_right_units(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting with a Quantity of the right SI units succeeds
+        contact.freq = 32 * unit_registry.hertz
+
+    def test_contact_freq_roundtrip(self):
+        contact = self.store.db_classes.Contact()
+
+        # Check setting and retrieving field works, and gives units as a result
+        contact.freq = 567 * unit_registry.hertz
+
+        assert contact.freq == 567 * unit_registry.hertz
+        assert contact.freq.check("[time]^-1")
+
+
 CLASSES_WITH_ELEVATION = [
     pytest.param("State", id="state"),
     pytest.param("Media", id="media"),


### PR DESCRIPTION
Converts the following Contact attributes to properties with unit checking. Also added new `range` column to schema, and property with unit checking for this too.

(Also fixed a few bugs in the datafile export that were hidden by the limited testing we're doing - see separate issue #225)

**Contact:**
- [x] bearing (angle)
- [x] rel_bearing (angle)
- [x] freq (hz)
- [x] range (length)
- [x] location 
- [x] elevation (length)
- [x] orientation  (angle) (orient, maj, min are ways of describing the ellipse )
- [x] major (length)
- [x] minor  (length)
- [x] MLA (angle)
- [x] SLA (angle)