### PR TITLE
Hotfix: Fix SOA name typo and change units to speed

### DIFF
--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -496,41 +496,41 @@ class ContactMixin:
         return self._mla
 
     #
-    # SLA properties
+    # SOA properties
     #
 
     @hybrid_property
-    def sla(self):
-        # Return all SLA's as degrees
-        if self._sla is None:
+    def soa(self):
+        # Return all soa's as degrees
+        if self._soa is None:
             return None
         else:
-            return (self._sla * unit_registry.radian).to(unit_registry.degree)
+            return (self._soa * unit_registry.radian).to(unit_registry.degree)
 
-    @sla.setter
-    def sla(self, sla):
-        if sla is None:
-            self._sla = None
+    @soa.setter
+    def soa(self, soa):
+        if soa is None:
+            self._soa = None
             return
 
         # Check the given bearing is a Quantity with a dimension of '' and units of
         # degrees or radians
         try:
-            if not sla.check(""):
+            if not soa.check(""):
                 raise ValueError(
-                    "SLA must be a Quantity with a dimensionality of '' (ie. nothing)"
+                    "SOA must be a Quantity with a dimensionality of '' (ie. nothing)"
                 )
             if not (
-                sla.units == unit_registry.degree or sla.units == unit_registry.radian
+                soa.units == unit_registry.degree or soa.units == unit_registry.radian
             ):
                 raise ValueError(
-                    "SLA must be a Quantity with angular units (degree or radian)"
+                    "SOA must be a Quantity with angular units (degree or radian)"
                 )
         except AttributeError:
-            raise TypeError("SLA must be a Quantity")
+            raise TypeError("SOA must be a Quantity")
 
         # Set the actual bearing attribute to the given value converted to radians
-        self._sla = sla.to(unit_registry.radian).magnitude
+        self._soa = soa.to(unit_registry.radian).magnitude
 
     #
     # Orientation properties

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -501,11 +501,11 @@ class ContactMixin:
 
     @hybrid_property
     def soa(self):
-        # Return all soa's as degrees
+        # Return all soas as metres per second
         if self._soa is None:
             return None
         else:
-            return (self._soa * unit_registry.radian).to(unit_registry.degree)
+            return self._soa * (unit_registry.metre / unit_registry.second)
 
     @soa.setter
     def soa(self, soa):
@@ -513,24 +513,21 @@ class ContactMixin:
             self._soa = None
             return
 
-        # Check the given bearing is a Quantity with a dimension of '' and units of
-        # degrees or radians
+        # Check the given soa is a Quantity with a dimension of 'length / time'
         try:
-            if not soa.check(""):
+            if not soa.check("[length]/[time]"):
                 raise ValueError(
-                    "SOA must be a Quantity with a dimensionality of '' (ie. nothing)"
-                )
-            if not (
-                soa.units == unit_registry.degree or soa.units == unit_registry.radian
-            ):
-                raise ValueError(
-                    "SOA must be a Quantity with angular units (degree or radian)"
+                    "SOA must be a Quantity with a dimensionality of [length]/[time]"
                 )
         except AttributeError:
             raise TypeError("SOA must be a Quantity")
 
-        # Set the actual bearing attribute to the given value converted to radians
-        self._soa = soa.to(unit_registry.radian).magnitude
+        # Set the actual soa attribute to the given value converted to metres per second
+        self._soa = soa.to(unit_registry.metre / unit_registry.second).magnitude
+
+    @soa.expression
+    def soa(self):
+        return self._soa
 
     #
     # Orientation properties

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -479,7 +479,7 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropert
     confidence = Column(String(150))
     contact_type = Column(String(150))
     _mla = Column(DOUBLE_PRECISION)
-    _sla = Column(DOUBLE_PRECISION)
+    _soa = Column(DOUBLE_PRECISION)
     subject_id = Column(UUID(as_uuid=True), ForeignKey("pepys.Platforms.platform_id"))
     source_id = Column(
         UUID(as_uuid=True), ForeignKey("pepys.Datafiles.datafile_id"), nullable=False

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -397,7 +397,7 @@ class Contact(
     confidence = Column(String(150))
     contact_type = Column(String(150))
     _mla = Column(REAL)
-    _sla = Column(REAL)
+    _soa = Column(REAL)
     subject_id = Column(Integer)
     source_id = Column(Integer, nullable=False)
     privacy_id = Column(Integer)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -368,7 +368,7 @@ class TestContactSLAProperty(unittest.TestCase):
         with pytest.raises(ValueError) as exception:
             contact.soa = 5 * unit_registry.second
 
-        assert "SOA must be a Quantity with a dimensionality of ''" in str(
+        assert "SOA must be a Quantity with a dimensionality of [length]/[time]" in str(
             exception.value
         )
 
@@ -376,19 +376,19 @@ class TestContactSLAProperty(unittest.TestCase):
         contact = self.store.db_classes.Contact()
 
         # Check setting with a Quantity of the right SI units succeeds
-        contact.soa = 57 * unit_registry.degree
+        contact.soa = 57 * (unit_registry.metre / unit_registry.second)
 
         # Check setting with a Quantity of strange but valid units succeeds
-        contact.soa = 0.784 * unit_registry.radian
+        contact.soa = 0.784 * (unit_registry.angstrom / unit_registry.day)
 
     def test_contact_soa_roundtrip(self):
         contact = self.store.db_classes.Contact()
 
         # Check setting and retrieving field works, and gives units as a result
-        contact.soa = 198 * unit_registry.degree
+        contact.soa = 19 * unit_registry.knot
 
-        assert contact.soa == 198 * unit_registry.degree
-        assert contact.soa.check("")
+        assert contact.soa == 19 * unit_registry.knot
+        assert contact.soa.check("[length]/[time]")
 
 
 class TestContactOrientationProperty(unittest.TestCase):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -345,50 +345,50 @@ class TestContactSLAProperty(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_contact_sla_none(self):
+    def test_contact_soa_none(self):
         contact = self.store.db_classes.Contact()
 
-        contact.sla = None
+        contact.soa = None
 
-        assert contact.sla is None
+        assert contact.soa is None
 
-    def test_contact_sla_scalar(self):
+    def test_contact_soa_scalar(self):
         contact = self.store.db_classes.Contact()
 
         # Check setting with a scalar (float) gives error
         with pytest.raises(TypeError) as exception:
-            contact.sla = 5
+            contact.soa = 5
 
-        assert "SLA must be a Quantity" in str(exception.value)
+        assert "SOA must be a Quantity" in str(exception.value)
 
-    def test_contact_sla_wrong_units(self):
+    def test_contact_soa_wrong_units(self):
         contact = self.store.db_classes.Contact()
 
         # Check setting with a Quantity of the wrong units gives error
         with pytest.raises(ValueError) as exception:
-            contact.sla = 5 * unit_registry.second
+            contact.soa = 5 * unit_registry.second
 
-        assert "SLA must be a Quantity with a dimensionality of ''" in str(
+        assert "SOA must be a Quantity with a dimensionality of ''" in str(
             exception.value
         )
 
-    def test_contact_sla_right_units(self):
+    def test_contact_soa_right_units(self):
         contact = self.store.db_classes.Contact()
 
         # Check setting with a Quantity of the right SI units succeeds
-        contact.sla = 57 * unit_registry.degree
+        contact.soa = 57 * unit_registry.degree
 
         # Check setting with a Quantity of strange but valid units succeeds
-        contact.sla = 0.784 * unit_registry.radian
+        contact.soa = 0.784 * unit_registry.radian
 
-    def test_contact_sla_roundtrip(self):
+    def test_contact_soa_roundtrip(self):
         contact = self.store.db_classes.Contact()
 
         # Check setting and retrieving field works, and gives units as a result
-        contact.sla = 198 * unit_registry.degree
+        contact.soa = 198 * unit_registry.degree
 
-        assert contact.sla == 198 * unit_registry.degree
-        assert contact.sla.check("")
+        assert contact.soa == 198 * unit_registry.degree
+        assert contact.soa.check("")
 
 
 class TestContactOrientationProperty(unittest.TestCase):


### PR DESCRIPTION
The Contact.SOA property was accidentally implemented as SLA. This PR changes it to SOA, and also changes the units from an angle to a speed.