### PR TITLE
Changed Send To shortcuts to have archive/no archive options

### DIFF
--- a/bin/create_shortcuts.ps1
+++ b/bin/create_shortcuts.ps1
@@ -24,8 +24,8 @@ $Shortcut.IconLocation = $icon_string
 $Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
 $Shortcut.Save()
 
-$Shortcut = $WshShell.CreateShortcut($sendto_location + "\Pepys Import (persist).lnk")
-$Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_import_persist.bat")
+$Shortcut = $WshShell.CreateShortcut($sendto_location + "\Pepys Import (no archive).lnk")
+$Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_import_no_archive.bat")
 $Shortcut.IconLocation = $icon_string
 $Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
 $Shortcut.Save()

--- a/bin/pepys_import_no_archive.bat
+++ b/bin/pepys_import_no_archive.bat
@@ -1,5 +1,5 @@
 CALL set_paths.bat
 REM note: when we're called via the "SendTo" link, the target is in the first argument
-python -m pepys_import.import --archive --path %1 %2 %3 %4 %5 %6 %7 %8
+python -m pepys_import.import --path %1 %2 %3 %4 %5 %6 %7 %8
 REM we're pausing the end of the script so we learn more about what is being processed
 PAUSE

--- a/bin/pepys_import_persist.bat
+++ b/bin/pepys_import_persist.bat
@@ -1,1 +1,0 @@
-call pepys_import %1 --db "%~dp1\pepys.db"


### PR DESCRIPTION
Changed the Windows Send To shortcuts created by `create_shortcuts.ps1` to create two shortcuts:

 - `Pepys Import` shortcut does archiving by default
 - `Pepys Import (no archive)` entry which doesn't do archiving