### PR TITLE
Cleanup Sphinx documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -53,74 +53,45 @@ If you are proposing a feature:
 * Keep the scope as narrow as possible, to make it easier to implement.
 * Contributions are always welcome :)
 
-Get Started!
-------------
+Code coverage
+-------------
 
-Ready to contribute? Here's how to set up `pepys_import` for local development.
+We're aiming for 100% code coverage on the project, track our progress
+here: |code_cov|
 
-1. Fork the `pepys_import` repo on GitHub.
-2. Clone your fork locally::
+.. |code_cov| image:: https://codecov.io/gh/debrief/pepys-import/branch/develop/graph/badge.svg
+   :target: https://codecov.io/gh/debrief/pepys-import/branch/develop
 
-    $ git clone git@github.com:your_name_here/pepys_import.git
+Upstream security
+-----------------
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+We have continuous vulnerability testing on the Open Source libraries
+we depend upon for development: |dev_req| and production: |plain_req|
 
-    $ mkvirtualenv pepys_import
-    $ cd pepys_import/
-    $ python setup.py develop
+.. |plain_req| image:: https://snyk.io/test/github/debrief/pepys-import/badge.svg?targetFile=requirements.txt
+   :target: https://snyk.io/test/github/debrief/pepys-import?targetFile=requirements.txt
 
-4. Create a branch for local development::
+.. |dev_req| image:: https://snyk.io/test/github/debrief/pepys-import/badge.svg?targetFile=requirements_dev.txt
+   :target: https://snyk.io/test/github/debrief/pepys-import?targetFile=requirements_dev.txt
 
-    $ git checkout -b name-of-your-bugfix-or-feature
+Code Style
+----------
+Black is used on the project: |black|
 
-   Now you can make your changes locally.
+.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+ :target: https://github.com/python/black
 
-5. When you're done making changes, check that your changes pass flake8 and the
-   tests, including testing other Python versions with tox::
+It is suggested to install a pre-commit hook in order to apply Black before pushing commits::
 
-    $ flake8 pepys_import tests
-    $ python setup.py test or pytest
-    $ tox
+    $ pip install pre-commit
+    $ pre-commit install
 
-   To get flake8 and tox, just pip install them into your virtualenv.
 
-6. Commit your changes and push your branch to GitHub::
+Windows-specific pre-commit instructions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+There are some minor issues with the pre-commit library on Windows. If you run into errors Installing
+the pre-commit hook, the follow the instructions at `this Github issue <https://github.com/pre-commit/pre-commit/issues/891>`_,
+by loading a Command Prompt with administrator permissions and running::
 
-    $ git add .
-    $ git commit -m "Your detailed description of your changes."
-    $ git push origin name-of-your-bugfix-or-feature
-
-7. Submit a pull request through the GitHub website.
-
-Pull Request Guidelines
------------------------
-
-Before you submit a pull request, check that it meets these guidelines:
-
-1. The pull request should include tests.
-2. If the pull request adds functionality, the docs should be updated. Put
-   your new functionality into a function with a docstring, and add the
-   feature to the list in README.rst.
-3. The pull request should work for Python 3.5, 3.6, 3.7 and 3.8, and for PyPy. Check
-   https://travis-ci.org/pepys_import/pull_requests
-   and make sure that the tests pass for all supported Python versions.
-
-Tips
-----
-
-To run all the tests::
-
-    $ python -m unittest discover tests
-
-Deploying
----------
-
-A reminder for the maintainers on how to deploy.
-Make sure all your changes are committed (including an entry in HISTORY.rst).
-Then run::
-
-$ bump2version patch # possible: major / minor / patch
-$ git push
-$ git push --tags
-
-Travis will then deploy to PyPI if tests pass.
+    $ pre-commit clean
+    $ pre-commit run black --all-files

--- a/DeveloperGuide.rst
+++ b/DeveloperGuide.rst
@@ -1,12 +1,9 @@
-###############
-Developer Guide
-###############
+===============
+Developer Setup
+===============
 
 This document provides instructions for setting up pepys-import for development, along with contributers
 guidance on code style, testing and so on.
-
-Setup
-=====
 
 To prepare for running ensure Python 3.6 or later is installed on your system.
 You can check your Python 3 version with the following command::
@@ -181,112 +178,3 @@ leaving off the .py file extension
 For example, to run the importer command-line interface, run::
 
     python -m pepys_import.import --path /path/to/file/to/import
-
-
-Contributing Notes
-==================
-
-Code coverage
--------------
-
-We're aiming for 100% code coverage on the project, track our progress
-here: |code_cov|
-
-.. |code_cov| image:: https://codecov.io/gh/debrief/pepys-import/branch/develop/graph/badge.svg
-   :target: https://codecov.io/gh/debrief/pepys-import/branch/develop
-
-Upstream security
------------------
-
-We have continuous vulnerability testing on the Open Source libraries
-we depend upon for development: |dev_req| and production: |plain_req|
-
-.. |plain_req| image:: https://snyk.io/test/github/debrief/pepys-import/badge.svg?targetFile=requirements.txt
-   :target: https://snyk.io/test/github/debrief/pepys-import?targetFile=requirements.txt
-
-.. |dev_req| image:: https://snyk.io/test/github/debrief/pepys-import/badge.svg?targetFile=requirements_dev.txt
-   :target: https://snyk.io/test/github/debrief/pepys-import?targetFile=requirements_dev.txt
-
-Code Style
-----------
-Black is used on the project: |black|
-
-.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
- :target: https://github.com/python/black
-
-It is suggested to install a pre-commit hook in order to apply Black before pushing commits::
-
-    $ pip install pre-commit
-    $ pre-commit install
-
-
-Windows-specific pre-commit instructions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-There are some minor issues with the pre-commit library on Windows. If you run into errors Installing
-the pre-commit hook, the follow the instructions at `this Github issue <https://github.com/pre-commit/pre-commit/issues/891>`_,
-by loading a Command Prompt with administrator permissions and running::
-
-    $ pre-commit clean
-    $ pre-commit run black --all-files
-
-Online documentation
-====================
-
-User-focused API documentation is available in the full documentation: |docs|
-
-.. |docs| image:: https://readthedocs.org/projects/pepys-import/badge/?version=latest
-  :target:  https://pepys-import.readthedocs.io/
-
-
-
-Project Progress
-================
-
-View the project Kanban board `here <https://github.com/debrief/pepys-import/projects/3>`_
-
-Creating a deployable release
-=============================
-
-For significant releases, the `pepys-import` version should be incremented,
-using:
-```
-bumpversion patch
-```
-
-Note 1: once the version has been incremented, a new entry should be
-included in `History.rst`.
-
-Note 2: _currently_ the substitution files on `pepys_import/__init__.py` and `setup.py`,
-and will need to be tidied manually.
-
-Pepys-import is deployed by providing a zip file to the client containing everything necessary to run
-pepys-import on a Windows 10 computer. For instructions on how to install from a deployable zip file,
-see `the user-focused README <https://github.com/debrief/pepys-import/blob/develop/README.rst>`_.
-
-To create a deployable release, follow the instructions below on a Windows 10 machine (this *cannot* be
-done from any other sort of computer):
-
-1. Clone a new copy of the `pepys-import repository <https://github.com/debrief/pepys-import/>`_, and make sure
-it is at the relevant commit for the version you want to release (we recommend creating a git tag for the commit
-you use as the basis for a release). (**Note:** Do not create a deployable release from a previously-cloned
-version of the repository that you have developed in - always clone a clean copy, otherwise extraneous files
-will be included in the release).
-
-2. Run the ``create_deployment.bat`` file in the root of the cloned repository. This will run the ``create_deployment.ps1``
-Powershell script. This script obtains all the required binary dependencies (including a standalone
-version of Python) and places them in the correct place in the folder hierarchy, and then zips up the
-entire folder, resulting in a file in the root of the cloned repository called ``pepys-import_HASH.zip``,
-where ``HASH`` is the git commit hash that the release was created from.
-
-3. Upload the resulting zip file to the Github Releases page.
-
-IntelliJ Instructions
-=====================
-
-To run from inside IntelliJ open the project
-Mark the :code:`Store` package as source by right clicking on
-the directory and selecting :code:`Mark Directory as -> Source Root`
-
-Open any python module you want to run in the main editor
-window, right click anywhere in the editor and choose the
-:code:`Run` or :code:`Debug` option

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -1,0 +1,35 @@
+Creating a deployable release
+=============================
+
+Pepys-import is deployed by providing a zip file to the client containing everything necessary to run
+pepys-import on a Windows 10 computer. For instructions on how to install from a deployable zip file,
+see `the user-focused README <https://github.com/debrief/pepys-import/blob/develop/README.rst>`_.
+
+For significant releases, the `pepys-import` version should be incremented,
+using::
+
+    bumpversion patch
+
+
+**Note 1:** once the version has been incremented, a new entry should be
+included in `History.rst`.
+
+**Note 2:** _currently_ the substitution files on `pepys_import/__init__.py` and `setup.py`,
+and will need to be tidied manually.
+
+To create a deployable release, follow the instructions below on a Windows 10 machine (this *cannot* be
+done from any other sort of computer):
+
+1. Clone a new copy of the `pepys-import repository <https://github.com/debrief/pepys-import/>`_, and make sure
+it is at the relevant commit for the version you want to release (we recommend creating a git tag for the commit
+you use as the basis for a release). (**Note:** Do not create a deployable release from a previously-cloned
+version of the repository that you have developed in - always clone a clean copy, otherwise extraneous files
+will be included in the release).
+
+2. Run the ``create_deployment.bat`` file in the root of the cloned repository. This will run the ``create_deployment.ps1``
+Powershell script. This script obtains all the required binary dependencies (including a standalone
+version of Python) and places them in the correct place in the folder hierarchy, and then zips up the
+entire folder, resulting in a file in the root of the cloned repository called ``pepys-import_HASH.zip``,
+where ``HASH`` is the git commit hash that the release was created from.
+
+3. Upload the resulting zip file to the Github Releases page.

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -1,0 +1,1 @@
+.. include:: ../DeveloperGuide.rst

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -1,6 +1,6 @@
-=============
+==================================
 Contributing to the Documentation
-=============
+==================================
 
 
 The source for Pepys Import documentation is in this directory. Our
@@ -18,7 +18,7 @@ Building the documentation
 
 If you would like regenerate the document structure:
 
-- :code:`sphinx-quickstart` `(link) <https://www.sphinx-doc.org/en/master/usage/quickstart.html#setting-up-the-documentation-sources>`_ can be called to set up a source directory and create necessary configurations.
-- Another option is using the following code: :code:`sphinx-apidoc -F -o docs pepys_import` `(link) <https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html>`_
+- :code:`sphinx-quickstart` `(sphinx-quickstart documentation) <https://www.sphinx-doc.org/en/master/usage/quickstart.html#setting-up-the-documentation-sources>`_ can be called to set up a source directory and create necessary configurations.
+- Another option is using the following code: :code:`sphinx-apidoc -F -o docs pepys_import` `(sphinx-apidoc documentation) <https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html>`_
 
 After it's done, you can run :code:`make html` in :code:`docs/` folder.

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -1,12 +1,12 @@
 =============
-Documentation
+Contributing to the Documentation
 =============
 
 
 The source for Pepys Import documentation is in this directory. Our
 documentation uses
-[Sphinx](https://www.sphinx-doc.org/en/master/index.html) and
-[Sphinx's RTD Theme](https://sphinx-rtd-theme.readthedocs.io/en/stable/).
+`Sphinx <https://www.sphinx-doc.org/en/master/index.html>`_ and
+`Sphinx's RTD Theme <https://sphinx-rtd-theme.readthedocs.io/en/stable/>`_.
 
 Building the documentation
 --------------------------
@@ -14,13 +14,11 @@ Building the documentation
 * Install requirements.txt in the top level of the
   project: :code:`pip install -r requirements.txt` .
 * From the top level directory, :code:`cd` into the
-  :code:`docs/` folder and run:
-
-    1. :code:`make html`
+  :code:`docs/` folder and run: :code:`make html`
 
 If you would like regenerate the document structure:
 
 - :code:`sphinx-quickstart` `(link) <https://www.sphinx-doc.org/en/master/usage/quickstart.html#setting-up-the-documentation-sources>`_ can be called to set up a source directory and create necessary configurations.
-- Another option is using the following code: :code:`sphinx-apidoc -F -o docs pepys_import` `(other_link) <https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html>`_
+- Another option is using the following code: :code:`sphinx-apidoc -F -o docs pepys_import` `(link) <https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html>`_
 
 After it's done, you can run :code:`make html` in :code:`docs/` folder.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,8 +6,6 @@
 Welcome to pepys-import
 =======================
 
-.. include:: ../README.rst
-
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
@@ -15,6 +13,8 @@ Welcome to pepys-import
    README.rst
    installation
    usage
+   developer_guide
+   deployment
    Source documentation <modules>
    contributing
    documentation

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,49 +4,15 @@
 Installation
 ============
 
+Deployable releases of pepys-import are available on the `Releases
+<https://github.com/debrief/pepys-import/releases>`_ page. Download the latest release and follow the
+instructions below to install:
 
-Stable release
---------------
+1. Extract the contents of the downloaded zip file into a folder of your choice (note, this can be
+anywhere, including on a shared network drive). This zip file contains everything that is needed
+to run pepys-import - including a standalone installation of Python, all of the Python dependencies,
+various required DLLs and the pepys-import code itself.
 
-To install pepys-import, run this command in your terminal:
-
-.. code-block:: console
-
-    $ pip install pepys_import
-
-This is the preferred method to install pepys-import, as it will
-always install the most recent stable release.
-
-If you don't have `pip`_ installed, this `Python installation guide`_ can guide
-you through the process.
-
-.. _pip: https://pip.pypa.io
-.. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
-
-
-From sources
-------------
-
-The sources for pepys-import can be downloaded from the `Github repo`_.
-
-You can either clone the public repository:
-
-.. code-block:: console
-
-    $ git clone git://github.com/debrief/pepys-import
-
-Or download the `tarball`_:
-
-.. code-block:: console
-
-    $ curl -OJL https://github.com/debrief/pepys-import/tarball/master
-
-Once you have a copy of the source, you can install it with:
-
-.. code-block:: console
-
-    $ python setup.py install
-
-
-.. _Github repo: https://github.com/debrief/pepys-import
-.. _tarball: https://github.com/debrief/pepys-import/tarball/master
+2. Once for each user who will use pepys-import, run ``create_shortcuts.bat`` in the ``bin`` directory.
+This will create shortcuts to the relevant pepys-import batch files (from the ``bin`` directory) and copy
+them to the user's *Send To* folder.

--- a/docs/pepys_import.core.formats.rst
+++ b/docs/pepys_import.core.formats.rst
@@ -20,18 +20,10 @@ pepys\_import.core.formats.location module
    :undoc-members:
    :show-inheritance:
 
-pepys\_import.core.formats.repl\_file module
---------------------------------------------
+pepys\_import.core.formats.rep\_line module
+-------------------------------------------
 
-.. automodule:: pepys_import.core.formats.repl_file
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-pepys\_import.core.formats.state module
----------------------------------------
-
-.. automodule:: pepys_import.core.formats.state
+.. automodule:: pepys_import.core.formats.rep_line
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/pepys_import.core.rst
+++ b/docs/pepys_import.core.rst
@@ -8,6 +8,7 @@ Subpackages
 
    pepys_import.core.formats
    pepys_import.core.store
+   pepys_import.core.validators
 
 Module contents
 ---------------

--- a/docs/pepys_import.core.store.rst
+++ b/docs/pepys_import.core.store.rst
@@ -4,6 +4,22 @@ pepys\_import.core.store package
 Submodules
 ----------
 
+pepys\_import.core.store.common\_db module
+------------------------------------------
+
+.. automodule:: pepys_import.core.store.common_db
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.core.store.constants module
+-----------------------------------------
+
+.. automodule:: pepys_import.core.store.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pepys\_import.core.store.data\_store module
 -------------------------------------------
 
@@ -40,6 +56,14 @@ pepys\_import.core.store.sqlite\_db module
 ------------------------------------------
 
 .. automodule:: pepys_import.core.store.sqlite_db
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.core.store.table\_summary module
+----------------------------------------------
+
+.. automodule:: pepys_import.core.store.table_summary
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/pepys_import.core.validators.rst
+++ b/docs/pepys_import.core.validators.rst
@@ -1,0 +1,38 @@
+pepys\_import.core.validators package
+=====================================
+
+Submodules
+----------
+
+pepys\_import.core.validators.basic\_validator module
+-----------------------------------------------------
+
+.. automodule:: pepys_import.core.validators.basic_validator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.core.validators.constants module
+----------------------------------------------
+
+.. automodule:: pepys_import.core.validators.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.core.validators.enhanced\_validator module
+--------------------------------------------------------
+
+.. automodule:: pepys_import.core.validators.enhanced_validator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: pepys_import.core.validators
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/pepys_import.file.highlighter.rst
+++ b/docs/pepys_import.file.highlighter.rst
@@ -1,0 +1,29 @@
+pepys\_import.file.highlighter package
+======================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+   pepys_import.file.highlighter.support
+
+Submodules
+----------
+
+pepys\_import.file.highlighter.highlighter module
+-------------------------------------------------
+
+.. automodule:: pepys_import.file.highlighter.highlighter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: pepys_import.file.highlighter
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/pepys_import.file.highlighter.support.rst
+++ b/docs/pepys_import.file.highlighter.support.rst
@@ -1,0 +1,78 @@
+pepys\_import.file.highlighter.support package
+==============================================
+
+Submodules
+----------
+
+pepys\_import.file.highlighter.support.char module
+--------------------------------------------------
+
+.. automodule:: pepys_import.file.highlighter.support.char
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.file.highlighter.support.color\_picker module
+-----------------------------------------------------------
+
+.. automodule:: pepys_import.file.highlighter.support.color_picker
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.file.highlighter.support.combine module
+-----------------------------------------------------
+
+.. automodule:: pepys_import.file.highlighter.support.combine
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.file.highlighter.support.export module
+----------------------------------------------------
+
+.. automodule:: pepys_import.file.highlighter.support.export
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.file.highlighter.support.line module
+--------------------------------------------------
+
+.. automodule:: pepys_import.file.highlighter.support.line
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.file.highlighter.support.test\_utils module
+---------------------------------------------------------
+
+.. automodule:: pepys_import.file.highlighter.support.test_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.file.highlighter.support.token module
+---------------------------------------------------
+
+.. automodule:: pepys_import.file.highlighter.support.token
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.file.highlighter.support.usages module
+----------------------------------------------------
+
+.. automodule:: pepys_import.file.highlighter.support.usages
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: pepys_import.file.highlighter.support
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/pepys_import.file.rst
+++ b/docs/pepys_import.file.rst
@@ -1,16 +1,15 @@
 pepys\_import.file package
 ==========================
 
+Subpackages
+-----------
+
+.. toctree::
+
+   pepys_import.file.highlighter
+
 Submodules
 ----------
-
-pepys\_import.file.core\_parser module
---------------------------------------
-
-.. automodule:: pepys_import.file.core_parser
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 pepys\_import.file.file\_processor module
 -----------------------------------------
@@ -20,10 +19,10 @@ pepys\_import.file.file\_processor module
    :undoc-members:
    :show-inheritance:
 
-pepys\_import.file.sample\_parser module
-----------------------------------------
+pepys\_import.file.importer module
+----------------------------------
 
-.. automodule:: pepys_import.file.sample_parser
+.. automodule:: pepys_import.file.importer
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/pepys_import.rst
+++ b/docs/pepys_import.rst
@@ -12,6 +12,18 @@ Subpackages
    pepys_import.resolvers
    pepys_import.utils
 
+Submodules
+----------
+
+pepys\_import.import module
+---------------------------
+
+.. automodule:: pepys_import.import
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 Module contents
 ---------------
 

--- a/docs/pepys_import.utils.rst
+++ b/docs/pepys_import.utils.rst
@@ -12,10 +12,58 @@ pepys\_import.utils.branding\_util module
    :undoc-members:
    :show-inheritance:
 
+pepys\_import.utils.config\_utils module
+----------------------------------------
+
+.. automodule:: pepys_import.utils.config_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pepys\_import.utils.data\_store\_utils module
 ---------------------------------------------
 
 .. automodule:: pepys_import.utils.data_store_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.utils.datafile\_utils module
+------------------------------------------
+
+.. automodule:: pepys_import.utils.datafile_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.utils.geoalchemy\_utils module
+--------------------------------------------
+
+.. automodule:: pepys_import.utils.geoalchemy_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.utils.import\_utils module
+----------------------------------------
+
+.. automodule:: pepys_import.utils.import_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.utils.unit\_utils module
+--------------------------------------
+
+.. automodule:: pepys_import.utils.unit_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pepys\_import.utils.value\_transforming\_utils module
+-----------------------------------------------------
+
+.. automodule:: pepys_import.utils.value_transforming_utils
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,18 +2,4 @@
 Usage
 =====
 
-To use pepys-import in a project::
-
-    from pepys_import.file.file_processor import FileProcessor
-    from pepys_import.file.replay_importer import ReplayImporter
-    from pepys_import.file.nmea_importer import NMEAImporter
-
-    # create file processor, give it target filename
-    processor = FileProcessor("trial_db.db")
-
-    # register a couple of sample parsers
-    processor.register_importer(ReplayImporter())
-    processor.register_importer(NMEAImporter())
-
-    # instruct Pepys to process this directory
-    processor.process(".")
+TODO

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -1099,7 +1099,7 @@ class DataStore(object):
 
     def add_to_logs(self, table, row_id, field=None, new_value=None, change_id=None):
         """
-        Adds the specified event to the :class:`Logs`table if not already present.
+        Adds the specified event to the :class:`Logs` table if not already present.
 
         :param table: Name of the table
         :param row_id: Entity ID of the tale
@@ -1124,7 +1124,7 @@ class DataStore(object):
 
     def add_to_changes(self, user, modified, reason):
         """
-        Adds the specified event to the :class:`Change`table if not already present.
+        Adds the specified event to the :class:`Change` table if not already present.
 
         :param user: Username of the current login
         :param modified: Change date

--- a/pepys_import/file/file_processor.py
+++ b/pepys_import/file/file_processor.py
@@ -325,6 +325,7 @@ class FileProcessor:
         :param importer: An importer module that must define the functions defined
         in the Importer base class
         :type importer: Importer
+        
         """
         self.importers.append(importer)
 

--- a/pepys_import/file/highlighter/highlighter.py
+++ b/pepys_import/file/highlighter/highlighter.py
@@ -46,9 +46,9 @@ class HighlightedFile:
         """
         Provide highlighted summary for this file
         Args:
-            filename (str): The name of the destination for the HTML output
-            include_key (bool): Whether to include a key at the bottom of the output
-            showing what each colour refers to
+        filename (str): The name of the destination for the HTML output
+        include_key (bool): Whether to include a key at the bottom of the output
+        showing what each colour refers to
         """
         if len(self.chars) > 0:
             export_report(filename, self.chars, self.dict_color, include_key)

--- a/pepys_import/utils/unit_utils.py
+++ b/pepys_import/utils/unit_utils.py
@@ -37,6 +37,7 @@ def convert_absolute_angle(angle, line_number, errors, error_type):
 def convert_speed(speed, units, line_number, errors, error_type):
     """
     Parses the given speed value into a float and assigns the given units
+    
     :param speed: Speed value in string format
     :type speed: String
     :param units: Units of the speed (as a pint unit instance)


### PR DESCRIPTION
There was a lot of stuff in the documentation that was out of date or incorrect, and it wasn't structured very well for adding any further docs - so I did a broad restructuring and cleanup.

Specifically, this included:

 - Re-organising the overall table of contents structure to include things like the developer guide
 - Removing incorrect Installation and Usage sections
 - Changing Markdown formatting to Restructured Text to work with Sphinx (some bits of Markdown were left over from older documents)
 - Re-running `sphinx-apidoc` to regenerate the API documentation so that we're not trying to document non-existent modules, and all new modules are included in the docs
 - Updating some docstrings in the Python code itself, so they don't produce errors when generating the Sphinx docs