### PR TITLE
Reorganise clear_db command into clear_db_contents and clear_db_schema, and add both to Admin CLI

### DIFF
--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -42,26 +42,21 @@ class InitialiseShell(cmd.Cmd):
 
     def do_cleardb(self, args):
         self.datastore.clear_db()
-        print("Cleared database")
 
     def do_create_pepys_schema(self, args):
         self.datastore.initialise()
-        print("Initialised database")
 
     def do_import_reference_data(self, args):
         with self.datastore.session_scope():
             self.datastore.populate_reference(self.csv_path)
-        print("Reference data imported")
 
     def do_import_metadata(self, args):
         with self.datastore.session_scope():
             self.datastore.populate_metadata(self.csv_path)
-        print("Metadata imported")
 
     def do_import_sample_measurements(self, args):
         with self.datastore.session_scope():
             self.datastore.populate_measurement(self.csv_path)
-        print("Sample measurements imported")
 
     def do_cancel(self, *args):
         return True

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -42,21 +42,26 @@ class InitialiseShell(cmd.Cmd):
 
     def do_cleardb(self, args):
         self.datastore.clear_db()
+        print("Cleared database")
 
     def do_create_pepys_schema(self, args):
         self.datastore.initialise()
+        print("Initialised database")
 
     def do_import_reference_data(self, args):
         with self.datastore.session_scope():
             self.datastore.populate_reference(self.csv_path)
+        print("Reference data imported")
 
     def do_import_metadata(self, args):
         with self.datastore.session_scope():
             self.datastore.populate_metadata(self.csv_path)
+        print("Metadata imported")
 
     def do_import_sample_measurements(self, args):
         with self.datastore.session_scope():
             self.datastore.populate_measurement(self.csv_path)
+        print("Sample measurements imported")
 
     def do_cancel(self, *args):
         return True

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -17,11 +17,15 @@ dirpath = os.path.dirname(os.path.abspath(__file__))
 
 
 class InitialiseShell(cmd.Cmd):
-    intro = (
-        "\n--- Menu --- \n (1) Clear database\n (2) Create Pepys schema\n"
-        " (3) Import Reference data\n (4) Import Metadata\n "
-        "(5) Import Sample Measurements\n (0) Exit\n"
-    )
+    intro = """--- Menu ---
+(1) Clear database contents
+(2) Clear database schema
+(3) Create Pepys schema
+(4) Import Reference data
+(5) Import Metadata
+(6) Import Sample Measurements
+(0) Exit
+"""
     prompt = "(initialise) "
 
     def __init__(self, datastore, parentShell, csv_path):
@@ -30,19 +34,24 @@ class InitialiseShell(cmd.Cmd):
         self.csv_path = csv_path
         self.aliases = {
             "0": self.do_cancel,
-            "1": self.do_cleardb,
-            "2": self.do_create_pepys_schema,
-            "3": self.do_import_reference_data,
-            "4": self.do_import_metadata,
-            "5": self.do_import_sample_measurements,
+            "1": self.do_cleardb_contents,
+            "2": self.do_cleardb_schema,
+            "3": self.do_create_pepys_schema,
+            "4": self.do_import_reference_data,
+            "5": self.do_import_metadata,
+            "6": self.do_import_sample_measurements,
         }
 
         if parentShell:
             self.prompt = parentShell.prompt.strip() + "/" + self.prompt
 
-    def do_cleardb(self, args):
-        self.datastore.clear_db()
-        print("Cleared database")
+    def do_cleardb_contents(self, args):
+        self.datastore.clear_db_contents()
+        print("Cleared database contents")
+
+    def do_cleardb_schema(self, args):
+        self.datastore.clear_db_schema()
+        print("Cleared database schema")
 
     def do_create_pepys_schema(self, args):
         self.datastore.initialise()
@@ -85,7 +94,12 @@ class InitialiseShell(cmd.Cmd):
 
 
 class AdminShell(cmd.Cmd):
-    intro = "\n--- Menu --- \n (1) Export\n " "(2) Initialise\n (3) Status\n (0) Exit\n"
+    intro = """--- Menu ---
+(1) Export
+(2) Initialise/Clear
+(3) Status
+(0) Exit
+"""
     prompt = "(pepys-admin) "
 
     def __init__(self, datastore, csv_path=dirpath):

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -1147,8 +1147,7 @@ class DataStore(object):
             meta = BasePostGIS.metadata
 
         with self.session_scope():
-            for table in reversed(meta.sorted_tables):
-                self.session.execute(table.delete())
+            meta.drop_all()
 
     def get_all_datafiles(self):
         """

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -1147,7 +1147,8 @@ class DataStore(object):
             meta = BasePostGIS.metadata
 
         with self.session_scope():
-            meta.drop_all()
+            for table in reversed(meta.sorted_tables):
+                self.session.execute(table.delete())
 
     def get_all_datafiles(self):
         """

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -1139,8 +1139,8 @@ class DataStore(object):
     # End of Metadata Maintenance
     #############################################################
 
-    def clear_db(self):
-        """Delete records of all database tables"""
+    def clear_db_contents(self):
+        """Delete contents of all database tables"""
         if self.db_type == "sqlite":
             meta = BaseSpatiaLite.metadata
         else:
@@ -1149,6 +1149,16 @@ class DataStore(object):
         with self.session_scope():
             for table in reversed(meta.sorted_tables):
                 self.session.execute(table.delete())
+
+    def clear_db_schema(self):
+        """Delete the database schema (ie all of the tables)"""
+        if self.db_type == "sqlite":
+            meta = BaseSpatiaLite.metadata
+        else:
+            meta = BasePostGIS.metadata
+
+        with self.session_scope():
+            meta.drop_all()
 
     def get_all_datafiles(self):
         """

--- a/tests/test_data_store_cleardb.py
+++ b/tests/test_data_store_cleardb.py
@@ -4,8 +4,12 @@ from pepys_import.core.store.data_store import DataStore
 from testing.postgresql import Postgresql
 from unittest import TestCase
 
+from sqlalchemy import inspect
 
-class DataStoreClearPostGISDBTestCase(TestCase):
+import platform
+
+
+class DataStoreClearContentsPostGISDBTestCase(TestCase):
     def setUp(self):
         self.store = None
         try:
@@ -25,7 +29,7 @@ class DataStoreClearPostGISDBTestCase(TestCase):
         except AttributeError:
             return
 
-    def test_postgres_cleardb(self):
+    def test_postgres_cleardb_contents(self):
         """Test whether all database tables are empty"""
         if self.store is None:
             self.skipTest("Postgres is not available. Test is skipping")
@@ -52,7 +56,7 @@ class DataStoreClearPostGISDBTestCase(TestCase):
         self.assertNotEqual(len(records), 0)
 
         # Clear records from all tables
-        data_store_postgres.clear_db()
+        data_store_postgres.clear_db_contents()
 
         with data_store_postgres.session_scope():
             records = data_store_postgres.session.query(
@@ -62,8 +66,8 @@ class DataStoreClearPostGISDBTestCase(TestCase):
         self.assertEqual(len(records), 0)
 
 
-class DataStoreClearSpatiaLiteTestCase(TestCase):
-    def test_sqlite_cleardb(self):
+class DataStoreClearContentsSpatiaLiteTestCase(TestCase):
+    def test_sqlite_cleardb_contents(self):
         """Test whether all database tables are empty"""
         data_store_sqlite = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
 
@@ -81,7 +85,7 @@ class DataStoreClearSpatiaLiteTestCase(TestCase):
         self.assertNotEqual(len(records), 0)
 
         # Clear records from all tables
-        data_store_sqlite.clear_db()
+        data_store_sqlite.clear_db_contents()
 
         with data_store_sqlite.session_scope():
             records = data_store_sqlite.session.query(
@@ -89,6 +93,95 @@ class DataStoreClearSpatiaLiteTestCase(TestCase):
             ).all()
 
         self.assertEqual(len(records), 0)
+
+
+class DataStoreClearSchemaPostGISTestCase(TestCase):
+    def setUp(self):
+        self.store = None
+        try:
+            self.store = Postgresql(
+                database="test",
+                host="localhost",
+                user="postgres",
+                password="postgres",
+                port=55527,
+            )
+        except RuntimeError:
+            print("PostgreSQL database couldn't be created! Test is skipping.")
+
+    def tearDown(self):
+        try:
+            self.store.stop()
+        except AttributeError:
+            return
+
+    def test_clear_db_schema(self):
+        if self.store is None:
+            self.skipTest("Postgres is not available. Test is skipping")
+
+        data_store_postgres = DataStore(
+            db_username="postgres",
+            db_password="postgres",
+            db_host="localhost",
+            db_port=55527,
+            db_name="test",
+        )
+
+        # inspector makes it possible to load lists of schema, table, column
+        # information for the sqlalchemy engine
+        inspector = inspect(data_store_postgres.engine)
+        table_names = inspector.get_table_names()
+        schema_names = inspector.get_schema_names()
+
+        # there must be no table and no schema for datastore at the beginning
+        self.assertEqual(len(table_names), 0)
+        self.assertNotIn("pepys", schema_names)
+
+        # creating database from schema
+        data_store_postgres.initialise()
+
+        # Clearing schema
+        data_store_postgres.clear_db_schema()
+
+        inspector = inspect(data_store_postgres.engine)
+        table_names = inspector.get_table_names(schema="pepys")
+        schema_names = inspector.get_schema_names()
+
+        # no tables must be left
+        self.assertEqual(len(table_names), 0)
+
+
+class DataStoreClearSchemaSpatiaLiteTestCase(TestCase):
+    def test_clear_db_schema(self):
+        """Test whether schemas created successfully on SQLite"""
+        data_store_sqlite = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+
+        # inspector makes it possible to load lists of schema, table, column
+        # information for the sqlalchemy engine
+        inspector = inspect(data_store_sqlite.engine)
+        table_names = inspector.get_table_names()
+
+        # there must be no table at the beginning
+        self.assertEqual(len(table_names), 0)
+
+        # creating database from schema
+        data_store_sqlite.initialise()
+
+        # clear the database schema
+        data_store_sqlite.clear_db_schema()
+
+        inspector = inspect(data_store_sqlite.engine)
+        table_names = inspector.get_table_names()
+
+        SYSTEM = platform.system()
+
+        if SYSTEM == "Windows":
+            correct_n_tables = 38
+        else:
+            correct_n_tables = 36
+
+        # Only the spatial tables (36, or 38 on Windows) must be created. A few of them tested
+        self.assertEqual(len(table_names), correct_n_tables)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously the `data_store.clear_db()` function cleared the *contents* of the database tables, not the actual schema itself. This PR re-organises this to two methods: `clear_db_contents()` and `clear_db_schema()`.

The Admin CLI has been altered so both are available, and tests have been added for `clear_db_schema()` (as that is the new one).