### PR TITLE
Hotfix - Add config for pre-commit so that it picks up toml file for options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,4 @@ repos:
     rev: 4.3.21
     hooks:
       - id: isort
+        additional_dependencies: [toml]


### PR DESCRIPTION
The previous configuration of pre-commit didn't seem to pick up the pyproject.toml options file, so black and isort were conflicting with each other again. Adding this extra line to the config file seems to fix it - and black and isort don't conflict anymore.