### PR TITLE
Extend REP parser tests 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,4 @@ repos:
     rev: 4.3.21
     hooks:
       - id: isort
+        additional_dependencies: [toml] 

--- a/tests/test_rep_file_parse.py
+++ b/tests/test_rep_file_parse.py
@@ -2,6 +2,7 @@ import datetime
 import unittest
 from contextlib import redirect_stdout
 from io import StringIO
+from math import isnan
 
 from pepys_import.core.formats import unit_registry
 from pepys_import.core.formats.location import Location
@@ -191,6 +192,18 @@ class BasicTests(unittest.TestCase):
         correct_loc.set_latitude_dms(53, 45.32, 0, "S")
         correct_loc.set_longitude_dms(23, 56.23, 0, "E")
         assert correct_loc == rep_line.location
+
+    def test_nan_depth(self):
+        rep_line = REPLine(
+            line_number=1,
+            line=create_test_line_object(
+                "100112\t120800\tSUBJECT\tVC\t60\t23\t40.25\tS\t000\t01\t25.86\tE\t109.08\t6.00\tNaN\tLabel"
+            ),
+            separator="\t",
+        )
+        assert rep_line.parse(self.error, self.message)
+
+        assert isnan(rep_line.depth)
 
 
 if __name__ == "__main__":

--- a/tests/test_rep_file_parse.py
+++ b/tests/test_rep_file_parse.py
@@ -177,6 +177,21 @@ class BasicTests(unittest.TestCase):
         correct_loc.set_longitude_decimal_degrees(23.495)
         assert correct_loc == rep_line.location
 
+    def test_zero_secs(self):
+        rep_line = REPLine(
+            line_number=1,
+            line=create_test_line_object(
+                "100112\t120800\tSUBJECT\tVC\t53\t45.32\t0\tS\t23\t56.23\t0\tE\t109.08\t6.00\t0.00\tLabel"
+            ),
+            separator="\t",
+        )
+        assert rep_line.parse(self.error, self.message)
+
+        correct_loc = Location()
+        correct_loc.set_latitude_dms(53, 45.32, 0, "S")
+        correct_loc.set_longitude_dms(23, 56.23, 0, "E")
+        assert correct_loc == rep_line.location
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rep_file_parse.py
+++ b/tests/test_rep_file_parse.py
@@ -205,6 +205,16 @@ class BasicTests(unittest.TestCase):
 
         assert isnan(rep_line.depth)
 
+    def test_extended_symbology(self):
+        rep_line = REPLine(
+            line_number=1,
+            line=create_test_line_object(
+                "100112\t120800\tSUBJECT\t@C[SYMBOL=torpedo,LAYER=Support]\t60\t23\t40.25\tS\t000\t01\t25.86\tE\t109.08\t6.00\t0.0\tLabel"
+            ),
+            separator="\t",
+        )
+        assert rep_line.parse(self.error, self.message)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rep_file_parse.py
+++ b/tests/test_rep_file_parse.py
@@ -162,6 +162,21 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(0.0, rep_line.depth)
         self.assertEqual("Label", rep_line.text_label)
 
+    def test_zero_mins_secs(self):
+        rep_line = REPLine(
+            line_number=1,
+            line=create_test_line_object(
+                "100112\t120800\tSUBJECT\tVC\t53.243\t0\t0\tS\t23.495\t00\t0\tE\t109.08\t6.00\t0.00\tLabel"
+            ),
+            separator="\t",
+        )
+        assert rep_line.parse(self.error, self.message)
+
+        correct_loc = Location()
+        correct_loc.set_latitude_decimal_degrees(-53.243)
+        correct_loc.set_longitude_decimal_degrees(23.495)
+        assert correct_loc == rep_line.location
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rep_file_parse.py
+++ b/tests/test_rep_file_parse.py
@@ -215,6 +215,13 @@ class BasicTests(unittest.TestCase):
         )
         assert rep_line.parse(self.error, self.message)
 
+        correct_loc = Location()
+        correct_loc.set_latitude_dms(60.0, 23.0, 40.25, "S")
+        correct_loc.set_longitude_dms(0.0, 1.0, 25.86, "E")
+
+        assert rep_line.location == correct_loc
+        assert rep_line.get_platform() == "SUBJECT"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Now checks all of the situations specified in https://github.com/debrief/pepys-import/issues/54

Specific things to add to tests:
* [x] Decimal degrees, with zeros for mins/seconds
* [x] Decimal minutes, with zeroes for seconds
* [x] `NaN` for depth
* [x] Presence of extended symbology fields (just ignore them)