### PR TITLE
Simplify __init__ for importers

### DIFF
--- a/importers/e_trac_importer.py
+++ b/importers/e_trac_importer.py
@@ -10,11 +10,11 @@ from pepys_import.utils.unit_utils import convert_absolute_angle, convert_speed
 
 class ETracImporter(Importer):
     def __init__(self, separator=" "):
-        name = "E-Trac Format Importer"
-        validation_level = constants.BASIC_LEVEL
-        short_name = "E-Trac Importer"
-
-        super().__init__(name, validation_level, short_name)
+        super().__init__(
+            name="E-Trac Format Importer",
+            validation_level=constants.BASIC_LEVEL,
+            short_name="E-Trac Importer",
+        )
         self.separator = separator
 
         self.text_label = None

--- a/importers/e_trac_importer.py
+++ b/importers/e_trac_importer.py
@@ -9,13 +9,11 @@ from pepys_import.utils.unit_utils import convert_absolute_angle, convert_speed
 
 
 class ETracImporter(Importer):
-    def __init__(
-        self,
-        name="E-Trac Format Importer",
-        validation_level=constants.BASIC_LEVEL,
-        short_name="E-Trac Importer",
-        separator=" ",
-    ):
+    def __init__(self, separator=" "):
+        name = "E-Trac Format Importer"
+        validation_level = constants.BASIC_LEVEL
+        short_name = "E-Trac Importer"
+
         super().__init__(name, validation_level, short_name)
         self.separator = separator
 

--- a/importers/gpx_importer.py
+++ b/importers/gpx_importer.py
@@ -10,12 +10,10 @@ from pepys_import.utils.unit_utils import convert_absolute_angle, convert_speed
 
 
 class GPXImporter(Importer):
-    def __init__(
-        self,
-        name="GPX Format Importer",
-        validation_level=constants.BASIC_LEVEL,
-        short_name="GPX Importer",
-    ):
+    def __init__(self):
+        name = ("GPX Format Importer",)
+        validation_level = (constants.BASIC_LEVEL,)
+        short_name = ("GPX Importer",)
         super().__init__(name, validation_level, short_name)
 
     def can_load_this_type(self, suffix):

--- a/importers/gpx_importer.py
+++ b/importers/gpx_importer.py
@@ -11,10 +11,11 @@ from pepys_import.utils.unit_utils import convert_absolute_angle, convert_speed
 
 class GPXImporter(Importer):
     def __init__(self):
-        name = ("GPX Format Importer",)
-        validation_level = (constants.BASIC_LEVEL,)
-        short_name = ("GPX Importer",)
-        super().__init__(name, validation_level, short_name)
+        super().__init__(
+            name="GPX Format Importer",
+            validation_level=constants.BASIC_LEVEL,
+            short_name="GPX Importer",
+        )
 
     def can_load_this_type(self, suffix):
         return suffix.upper() == ".GPX"

--- a/importers/nmea_importer.py
+++ b/importers/nmea_importer.py
@@ -12,12 +12,13 @@ from pepys_import.utils.unit_utils import convert_absolute_angle, convert_speed
 
 class NMEAImporter(Importer):
     def __init__(
-        self,
-        name="NMEA File Format Importer",
-        validation_level=constants.BASIC_LEVEL,
-        short_name="NMEA Importer",
-        separator=",",
+        self, separator=",",
     ):
+
+        name = "NMEA File Format Importer"
+        validation_level = constants.BASIC_LEVEL
+        short_name = "NMEA Importer"
+
         super().__init__(name, validation_level, short_name)
         self.separator = separator
 

--- a/importers/nmea_importer.py
+++ b/importers/nmea_importer.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-from tqdm import tqdm
-
 from pepys_import.core.formats import unit_registry
 from pepys_import.core.formats.location import Location
 from pepys_import.core.validators import constants
@@ -11,15 +9,12 @@ from pepys_import.utils.unit_utils import convert_absolute_angle, convert_speed
 
 
 class NMEAImporter(Importer):
-    def __init__(
-        self, separator=",",
-    ):
-
-        name = "NMEA File Format Importer"
-        validation_level = constants.BASIC_LEVEL
-        short_name = "NMEA Importer"
-
-        super().__init__(name, validation_level, short_name)
+    def __init__(self, separator=","):
+        super().__init__(
+            name="NMEA File Format Importer",
+            validation_level=constants.BASIC_LEVEL,
+            short_name="NMEA Importer",
+        )
         self.separator = separator
 
         self.latitude = None

--- a/importers/replay_comment_importer.py
+++ b/importers/replay_comment_importer.py
@@ -7,12 +7,10 @@ from pepys_import.file.importer import Importer
 
 
 class ReplayCommentImporter(Importer):
-    def __init__(
-        self,
-        name="Replay Comment Importer",
-        validation_level=constants.ENHANCED_LEVEL,
-        short_name="REP Comment Importer",
-    ):
+    def __init__(self):
+        name = "Replay Comment Importer"
+        validation_level = constants.ENHANCED_LEVEL
+        short_name = "REP Comment Importer"
         super().__init__(name, validation_level, short_name)
         self.text_label = None
         self.depth = 0.0

--- a/importers/replay_comment_importer.py
+++ b/importers/replay_comment_importer.py
@@ -8,10 +8,11 @@ from pepys_import.file.importer import Importer
 
 class ReplayCommentImporter(Importer):
     def __init__(self):
-        name = "Replay Comment Importer"
-        validation_level = constants.ENHANCED_LEVEL
-        short_name = "REP Comment Importer"
-        super().__init__(name, validation_level, short_name)
+        super().__init__(
+            name="Replay Comment Importer",
+            validation_level=constants.ENHANCED_LEVEL,
+            short_name="REP Comment Importer",
+        )
         self.text_label = None
         self.depth = 0.0
 

--- a/importers/replay_contact_importer.py
+++ b/importers/replay_contact_importer.py
@@ -1,5 +1,3 @@
-from tqdm import tqdm
-
 from pepys_import.core.formats import unit_registry
 from pepys_import.core.formats.location import Location
 from pepys_import.core.formats.rep_line import parse_timestamp
@@ -15,11 +13,11 @@ from pepys_import.utils.unit_utils import (
 
 class ReplayContactImporter(Importer):
     def __init__(self):
-        name = "Replay Contact Importer"
-        validation_level = constants.ENHANCED_LEVEL
-        short_name = "REP Contact Importer"
-
-        super().__init__(name, validation_level, short_name)
+        super().__init__(
+            name="Replay Contact Importer",
+            validation_level=constants.ENHANCED_LEVEL,
+            short_name="REP Contact Importer",
+        )
         self.text_label = None
         self.depth = 0.0
 

--- a/importers/replay_contact_importer.py
+++ b/importers/replay_contact_importer.py
@@ -14,12 +14,11 @@ from pepys_import.utils.unit_utils import (
 
 
 class ReplayContactImporter(Importer):
-    def __init__(
-        self,
-        name="Replay Contact Importer",
-        validation_level=constants.ENHANCED_LEVEL,
-        short_name="REP Contact Importer",
-    ):
+    def __init__(self):
+        name = "Replay Contact Importer"
+        validation_level = constants.ENHANCED_LEVEL
+        short_name = "REP Contact Importer"
+
         super().__init__(name, validation_level, short_name)
         self.text_label = None
         self.depth = 0.0

--- a/importers/replay_importer.py
+++ b/importers/replay_importer.py
@@ -8,12 +8,13 @@ from pepys_import.file.importer import Importer
 
 class ReplayImporter(Importer):
     def __init__(
-        self,
-        name="Replay File Format Importer",
-        validation_level=constants.ENHANCED_LEVEL,
-        short_name="REP Importer",
-        separator=" ",
+        self, separator=" ",
     ):
+
+        name = "Replay File Format Importer"
+        validation_level = constants.ENHANCED_LEVEL
+        short_name = "REP Importer"
+
         super().__init__(name, validation_level, short_name)
         self.separator = separator
         self.text_label = None

--- a/importers/replay_importer.py
+++ b/importers/replay_importer.py
@@ -1,5 +1,3 @@
-from tqdm import tqdm
-
 from pepys_import.core.formats import unit_registry
 from pepys_import.core.formats.rep_line import REPLine
 from pepys_import.core.validators import constants
@@ -7,15 +5,12 @@ from pepys_import.file.importer import Importer
 
 
 class ReplayImporter(Importer):
-    def __init__(
-        self, separator=" ",
-    ):
-
-        name = "Replay File Format Importer"
-        validation_level = constants.ENHANCED_LEVEL
-        short_name = "REP Importer"
-
-        super().__init__(name, validation_level, short_name)
+    def __init__(self, separator=" "):
+        super().__init__(
+            name="Replay File Format Importer",
+            validation_level=constants.ENHANCED_LEVEL,
+            short_name="REP Importer",
+        )
         self.separator = separator
         self.text_label = None
         self.depth = 0.0


### PR DESCRIPTION
This PR converts the __init__ method of importers, so that we don't pass arguments to __init__ just to super()._init__. Generally makes it simpler for parser-writers.