### PR TITLE
Marked all tests that require Postgres, so that they can be excluded from test runs

### DIFF
--- a/DeveloperGuide.rst
+++ b/DeveloperGuide.rst
@@ -158,6 +158,11 @@ To run the unittests run::
 
     $ pytest tests/
 
+To run the unittests excluding the tests that require PostgreSQL (for example, if you couldn't install
+PostgreSQL earlier)::
+
+    $ pytest tests/ -m "not postgres"
+
 To view the coverage of the test suite, run::
 
     $ coverage run -m pytest tests/
@@ -165,16 +170,3 @@ To view the coverage of the test suite, run::
 and then view the report with::
 
     $ coverage report
-
-Run pepys-import from the command-line
---------------------------------------
-
-To run from the command line go to the top level directory of the library in
-your terminal.
-
-Run by specifying the program as a module with :code:`-m` and
-leaving off the .py file extension
-
-For example, to run the importer command-line interface, run::
-
-    python -m pepys_import.import --path /path/to/file/to/import

--- a/docs/importer_dev_guide.rst
+++ b/docs/importer_dev_guide.rst
@@ -369,14 +369,18 @@ the example below:
 Parser development environment and testing
 ------------------------------------------
 
-Create full development environment
-###################################
+Ensure development environment is set up correctly
+##################################################
+The deployed version of pepys-import contains all the development dependencies, except for a local
+install of PostgreSQL. To check everything is set up correctly, run all the tests _excluding_ those
+that require PostgreSQL by following these steps:
 
-Currently, the deployed version of pepys-import does not include the relevant libraries to be able
-to run the test framework (TODO: update this if/when this changes). Therefore, to develop parsers
-and run tests you will need to install a full development version following the instructions at
-`https://github.com/debrief/pepys-import/blob/develop/DeveloperGuide.rst
-<https://github.com/debrief/pepys-import/blob/develop/DeveloperGuide.rst>`__.
+1. Open a Windows Command Prompt
+2. Change to the directory containing the pepys-import installation
+3. Run :code:`cd bin` to change to the bin directory
+4. Run :code:`set_paths.bat` to set up the relevant paths to Python and its dependencies
+5. Run :code:`cd ..` to change back to the main directory
+6. Run :code:`python -m pytest tests/ -m "not postgres"` to run all tests excluding the PostgreSQL tests
 
 Start developing parser
 #######################

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    postgres: marks tests as requiring a local postgres executable (deselect with '-m "not postgres"')

--- a/tests/test_data_store_api_postgis.py
+++ b/tests/test_data_store_api_postgis.py
@@ -16,6 +16,7 @@ FILE_PATH = os.path.dirname(__file__)
 TEST_DATA_PATH = os.path.join(FILE_PATH, "sample_data", "csv_files")
 
 
+@pytest.mark.postgres
 class DataStoreCacheTestCase(TestCase):
     def setUp(self) -> None:
         self.postgres = None
@@ -50,7 +51,6 @@ class DataStoreCacheTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_cached_comment_types(self):
         """Test whether a new comment type entity cached and returned"""
         with self.store.session_scope():
@@ -71,7 +71,6 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(comment_types), 1)
 
-    @pytest.mark.postgres
     def test_cached_platform_types(self):
         """Test whether a new platform type entity cached and returned"""
         with self.store.session_scope():
@@ -95,7 +94,6 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(platform_types), 1)
 
-    @pytest.mark.postgres
     def test_cached_nationalities(self):
         """Test whether a new nationality entity cached and returned"""
         with self.store.session_scope():
@@ -115,7 +113,6 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(nationalities), 1)
 
-    @pytest.mark.postgres
     def test_cached_privacies(self):
         """Test whether a new privacy entity cached and returned"""
         with self.store.session_scope():
@@ -135,7 +132,6 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(privacies), 1)
 
-    @pytest.mark.postgres
     def test_cached_datafile_types(self):
         """Test whether a new datafile type entity cached and returned"""
         with self.store.session_scope():
@@ -159,7 +155,6 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(datafile_types), 1)
 
-    @pytest.mark.postgres
     def test_cached_sensor_types(self):
         """Test whether a new sensor type entity cached and returned"""
         with self.store.session_scope():
@@ -180,6 +175,7 @@ class DataStoreCacheTestCase(TestCase):
             self.assertEqual(len(sensor_types), 1)
 
 
+@pytest.mark.postgres
 class LookUpDBAndAddToCacheTestCase(TestCase):
     """Test searching functionality and adding existing DB entities to the cache of
     DataStore"""
@@ -217,7 +213,6 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_comment_types(self):
         with self.store.session_scope():
             comment_type = self.store.db_classes.CommentType(name="test")
@@ -236,7 +231,6 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(comment_types), 1)
 
-    @pytest.mark.postgres
     def test_platform_types(self):
         with self.store.session_scope():
             platform_type = self.store.db_classes.PlatformType(name="test")
@@ -255,7 +249,6 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(platform_types), 1)
 
-    @pytest.mark.postgres
     def test_nationalities(self):
         with self.store.session_scope():
             nationality = self.store.db_classes.Nationality(name="test")
@@ -274,7 +267,6 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(nationalities), 1)
 
-    @pytest.mark.postgres
     def test_privacies(self):
         with self.store.session_scope():
             privacy = self.store.db_classes.Privacy(name="test")
@@ -293,7 +285,6 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(privacies), 1)
 
-    @pytest.mark.postgres
     def test_datafile_types(self):
         with self.store.session_scope():
             datafile_type = self.store.db_classes.DatafileType(name="test")
@@ -312,7 +303,6 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(datafile_types), 1)
 
-    @pytest.mark.postgres
     def test_sensor_types(self):
         with self.store.session_scope():
             sensor_type = self.store.db_classes.SensorType(name="test")
@@ -332,6 +322,7 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             self.assertEqual(len(sensor_types), 1)
 
 
+@pytest.mark.postgres
 class PlatformAndDatafileTestCase(TestCase):
     def setUp(self) -> None:
         self.postgres = None
@@ -373,7 +364,6 @@ class PlatformAndDatafileTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_new_datafile_added_successfully(self):
         """Test whether a new datafile is created successfully or not"""
 
@@ -392,7 +382,6 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(len(datafiles), 1)
             self.assertEqual(datafiles[0].reference, "test_file.csv")
 
-    @pytest.mark.postgres
     def test_present_datafile_not_added(self):
         """Test whether present datafile is not created"""
 
@@ -411,7 +400,6 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(len(datafiles), 1)
             self.assertEqual(datafiles[0].reference, "test_file.csv")
 
-    @pytest.mark.postgres
     def test_find_datafile(self):
         """Test whether find_datafile method returns the correct Datafile entity"""
         with self.store.session_scope():
@@ -425,7 +413,6 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(datafile.datafile_id, found_datafile.datafile_id)
             self.assertEqual(found_datafile.reference, "test_file.csv")
 
-    @pytest.mark.postgres
     def test_find_datafile_synonym(self):
         """Test whether find_datafile method finds the correct Datafile entity from Synonyms table"""
         with self.store.session_scope():
@@ -443,7 +430,6 @@ class PlatformAndDatafileTestCase(TestCase):
             found_datafile = self.store.find_datafile("TEST")
             self.assertEqual(datafile.datafile_id, found_datafile.datafile_id)
 
-    @pytest.mark.postgres
     def test_new_platform_added_successfully(self):
         """Test whether a new platform is created successfully or not"""
 
@@ -469,7 +455,6 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(len(platforms), 1)
             self.assertEqual(platforms[0].name, "Test Platform")
 
-    @pytest.mark.postgres
     def test_present_platform_not_added(self):
         """Test whether present platform is not created"""
 
@@ -502,7 +487,6 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(len(platforms), 1)
             self.assertEqual(platforms[0].name, "Test Platform")
 
-    @pytest.mark.postgres
     def test_find_platform(self):
         """Test whether find_platform method returns the correct Platform entity"""
         with self.store.session_scope():
@@ -526,7 +510,6 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(platform.platform_id, found_platform.platform_id)
             self.assertEqual(found_platform.name, "Test Platform")
 
-    @pytest.mark.postgres
     def test_find_platform_synonym(self):
         """Test whether find_platform method finds the correct Platform entity from Synonyms table"""
         with self.store.session_scope():
@@ -557,6 +540,7 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(found_platform.name, "Test Platform")
 
 
+@pytest.mark.postgres
 class DataStoreStatusTestCase(TestCase):
     def setUp(self) -> None:
         self.postgres = None
@@ -591,7 +575,6 @@ class DataStoreStatusTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_get_status_of_measurement(self):
         """Test whether summary contents correct for measurement tables"""
 
@@ -604,7 +587,6 @@ class DataStoreStatusTestCase(TestCase):
         self.assertIn("Contacts", report)
         self.assertIn("Activations", report)
 
-    @pytest.mark.postgres
     def test_get_status_of_metadata(self):
         """Test whether summary contents correct for metadata tables"""
 
@@ -617,7 +599,6 @@ class DataStoreStatusTestCase(TestCase):
         self.assertIn("Platforms", report)
         self.assertIn("Datafiles", report)
 
-    @pytest.mark.postgres
     def test_get_status_of_reference(self):
         """Test whether summary contents correct for reference tables"""
 
@@ -631,6 +612,7 @@ class DataStoreStatusTestCase(TestCase):
         self.assertIn("PlatformTypes", report)
 
 
+@pytest.mark.postgres
 class SensorTestCase(TestCase):
     def setUp(self) -> None:
         self.postgres = None
@@ -685,7 +667,6 @@ class SensorTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_new_sensor_added_successfully(self):
         """Test whether a new sensor is created"""
         with self.store.session_scope():
@@ -701,7 +682,6 @@ class SensorTestCase(TestCase):
             self.assertEqual(len(sensors), 1)
             self.assertEqual(sensors[0].name, "gps")
 
-    @pytest.mark.postgres
     def test_present_sensor_not_added(self):
         """Test whether present sensor is not created"""
         with self.store.session_scope():
@@ -720,7 +700,6 @@ class SensorTestCase(TestCase):
 
             self.assertEqual(len(sensors), 1)
 
-    @pytest.mark.postgres
     def test_find_sensor(self):
         """Test whether find_sensor method returns the correct Sensor entity"""
         with self.store.session_scope():
@@ -742,7 +721,6 @@ class SensorTestCase(TestCase):
             self.assertEqual(sensor.sensor_id, found_sensor.sensor_id)
             self.assertEqual(found_sensor.name, "gps")
 
-    @pytest.mark.postgres
     def test_find_sensor_synonym(self):
         """Test whether find_sensor method finds the correct Sensor entity from Synonyms table"""
         with self.store.session_scope():
@@ -771,6 +749,7 @@ class SensorTestCase(TestCase):
             self.assertEqual(found_sensor.name, "gps")
 
 
+@pytest.mark.postgres
 class MeasurementsTestCase(TestCase):
     def setUp(self) -> None:
         self.postgres = None
@@ -868,7 +847,6 @@ class MeasurementsTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_new_state_created_successfully(self):
         """Test whether a new state is created"""
         with self.store.session_scope():
@@ -896,7 +874,6 @@ class MeasurementsTestCase(TestCase):
                 states = self.store.session.query(self.store.db_classes.State).all()
             self.assertEqual(len(states), 1)
 
-    @pytest.mark.postgres
     def test_new_contact_created_successfully(self):
         """Test whether a new contact is created"""
 
@@ -926,7 +903,6 @@ class MeasurementsTestCase(TestCase):
                 contacts = self.store.session.query(self.store.db_classes.Contact).all()
                 self.assertEqual(len(contacts), 1)
 
-    @pytest.mark.postgres
     def test_new_comment_created_successfully(self):
         """Test whether a new comment is created"""
 

--- a/tests/test_data_store_api_postgis.py
+++ b/tests/test_data_store_api_postgis.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from sqlite3 import OperationalError
 from unittest import TestCase
 
+import pytest
 from testing.postgresql import Postgresql
 
 from pepys_import.core.store import constants
@@ -49,6 +50,7 @@ class DataStoreCacheTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_cached_comment_types(self):
         """Test whether a new comment type entity cached and returned"""
         with self.store.session_scope():
@@ -69,6 +71,7 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(comment_types), 1)
 
+    @pytest.mark.postgres
     def test_cached_platform_types(self):
         """Test whether a new platform type entity cached and returned"""
         with self.store.session_scope():
@@ -92,6 +95,7 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(platform_types), 1)
 
+    @pytest.mark.postgres
     def test_cached_nationalities(self):
         """Test whether a new nationality entity cached and returned"""
         with self.store.session_scope():
@@ -111,6 +115,7 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(nationalities), 1)
 
+    @pytest.mark.postgres
     def test_cached_privacies(self):
         """Test whether a new privacy entity cached and returned"""
         with self.store.session_scope():
@@ -130,6 +135,7 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(privacies), 1)
 
+    @pytest.mark.postgres
     def test_cached_datafile_types(self):
         """Test whether a new datafile type entity cached and returned"""
         with self.store.session_scope():
@@ -153,6 +159,7 @@ class DataStoreCacheTestCase(TestCase):
             # there must be only one entity at the beginning
             self.assertEqual(len(datafile_types), 1)
 
+    @pytest.mark.postgres
     def test_cached_sensor_types(self):
         """Test whether a new sensor type entity cached and returned"""
         with self.store.session_scope():
@@ -210,6 +217,7 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_comment_types(self):
         with self.store.session_scope():
             comment_type = self.store.db_classes.CommentType(name="test")
@@ -228,6 +236,7 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(comment_types), 1)
 
+    @pytest.mark.postgres
     def test_platform_types(self):
         with self.store.session_scope():
             platform_type = self.store.db_classes.PlatformType(name="test")
@@ -246,6 +255,7 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(platform_types), 1)
 
+    @pytest.mark.postgres
     def test_nationalities(self):
         with self.store.session_scope():
             nationality = self.store.db_classes.Nationality(name="test")
@@ -264,6 +274,7 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(nationalities), 1)
 
+    @pytest.mark.postgres
     def test_privacies(self):
         with self.store.session_scope():
             privacy = self.store.db_classes.Privacy(name="test")
@@ -282,6 +293,7 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(privacies), 1)
 
+    @pytest.mark.postgres
     def test_datafile_types(self):
         with self.store.session_scope():
             datafile_type = self.store.db_classes.DatafileType(name="test")
@@ -300,6 +312,7 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
             # there must be only one entity again
             self.assertEqual(len(datafile_types), 1)
 
+    @pytest.mark.postgres
     def test_sensor_types(self):
         with self.store.session_scope():
             sensor_type = self.store.db_classes.SensorType(name="test")
@@ -360,6 +373,7 @@ class PlatformAndDatafileTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_new_datafile_added_successfully(self):
         """Test whether a new datafile is created successfully or not"""
 
@@ -378,6 +392,7 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(len(datafiles), 1)
             self.assertEqual(datafiles[0].reference, "test_file.csv")
 
+    @pytest.mark.postgres
     def test_present_datafile_not_added(self):
         """Test whether present datafile is not created"""
 
@@ -396,6 +411,7 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(len(datafiles), 1)
             self.assertEqual(datafiles[0].reference, "test_file.csv")
 
+    @pytest.mark.postgres
     def test_find_datafile(self):
         """Test whether find_datafile method returns the correct Datafile entity"""
         with self.store.session_scope():
@@ -409,6 +425,7 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(datafile.datafile_id, found_datafile.datafile_id)
             self.assertEqual(found_datafile.reference, "test_file.csv")
 
+    @pytest.mark.postgres
     def test_find_datafile_synonym(self):
         """Test whether find_datafile method finds the correct Datafile entity from Synonyms table"""
         with self.store.session_scope():
@@ -426,6 +443,7 @@ class PlatformAndDatafileTestCase(TestCase):
             found_datafile = self.store.find_datafile("TEST")
             self.assertEqual(datafile.datafile_id, found_datafile.datafile_id)
 
+    @pytest.mark.postgres
     def test_new_platform_added_successfully(self):
         """Test whether a new platform is created successfully or not"""
 
@@ -451,6 +469,7 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(len(platforms), 1)
             self.assertEqual(platforms[0].name, "Test Platform")
 
+    @pytest.mark.postgres
     def test_present_platform_not_added(self):
         """Test whether present platform is not created"""
 
@@ -483,6 +502,7 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(len(platforms), 1)
             self.assertEqual(platforms[0].name, "Test Platform")
 
+    @pytest.mark.postgres
     def test_find_platform(self):
         """Test whether find_platform method returns the correct Platform entity"""
         with self.store.session_scope():
@@ -506,6 +526,7 @@ class PlatformAndDatafileTestCase(TestCase):
             self.assertEqual(platform.platform_id, found_platform.platform_id)
             self.assertEqual(found_platform.name, "Test Platform")
 
+    @pytest.mark.postgres
     def test_find_platform_synonym(self):
         """Test whether find_platform method finds the correct Platform entity from Synonyms table"""
         with self.store.session_scope():
@@ -570,6 +591,7 @@ class DataStoreStatusTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_get_status_of_measurement(self):
         """Test whether summary contents correct for measurement tables"""
 
@@ -582,6 +604,7 @@ class DataStoreStatusTestCase(TestCase):
         self.assertIn("Contacts", report)
         self.assertIn("Activations", report)
 
+    @pytest.mark.postgres
     def test_get_status_of_metadata(self):
         """Test whether summary contents correct for metadata tables"""
 
@@ -594,6 +617,7 @@ class DataStoreStatusTestCase(TestCase):
         self.assertIn("Platforms", report)
         self.assertIn("Datafiles", report)
 
+    @pytest.mark.postgres
     def test_get_status_of_reference(self):
         """Test whether summary contents correct for reference tables"""
 
@@ -661,6 +685,7 @@ class SensorTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_new_sensor_added_successfully(self):
         """Test whether a new sensor is created"""
         with self.store.session_scope():
@@ -676,6 +701,7 @@ class SensorTestCase(TestCase):
             self.assertEqual(len(sensors), 1)
             self.assertEqual(sensors[0].name, "gps")
 
+    @pytest.mark.postgres
     def test_present_sensor_not_added(self):
         """Test whether present sensor is not created"""
         with self.store.session_scope():
@@ -694,6 +720,7 @@ class SensorTestCase(TestCase):
 
             self.assertEqual(len(sensors), 1)
 
+    @pytest.mark.postgres
     def test_find_sensor(self):
         """Test whether find_sensor method returns the correct Sensor entity"""
         with self.store.session_scope():
@@ -715,6 +742,7 @@ class SensorTestCase(TestCase):
             self.assertEqual(sensor.sensor_id, found_sensor.sensor_id)
             self.assertEqual(found_sensor.name, "gps")
 
+    @pytest.mark.postgres
     def test_find_sensor_synonym(self):
         """Test whether find_sensor method finds the correct Sensor entity from Synonyms table"""
         with self.store.session_scope():
@@ -840,6 +868,7 @@ class MeasurementsTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_new_state_created_successfully(self):
         """Test whether a new state is created"""
         with self.store.session_scope():
@@ -867,6 +896,7 @@ class MeasurementsTestCase(TestCase):
                 states = self.store.session.query(self.store.db_classes.State).all()
             self.assertEqual(len(states), 1)
 
+    @pytest.mark.postgres
     def test_new_contact_created_successfully(self):
         """Test whether a new contact is created"""
 
@@ -896,6 +926,7 @@ class MeasurementsTestCase(TestCase):
                 contacts = self.store.session.query(self.store.db_classes.Contact).all()
                 self.assertEqual(len(contacts), 1)
 
+    @pytest.mark.postgres
     def test_new_comment_created_successfully(self):
         """Test whether a new comment is created"""
 

--- a/tests/test_data_store_clear_db.py
+++ b/tests/test_data_store_clear_db.py
@@ -2,6 +2,7 @@ import platform
 import unittest
 from unittest import TestCase
 
+import pytest
 from sqlalchemy import inspect
 from testing.postgresql import Postgresql
 

--- a/tests/test_data_store_clear_db.py
+++ b/tests/test_data_store_clear_db.py
@@ -24,6 +24,7 @@ class DataStoreClearContentsPostGISDBTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_postgres_clear_db_contents(self):
         """Test whether all database tables are empty"""
         if self.store is None:
@@ -107,6 +108,7 @@ class DataStoreClearSchemaPostGISTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_clear_db_schema(self):
         if self.store is None:
             self.skipTest("Postgres is not available. Test is skipping")

--- a/tests/test_data_store_clear_db.py
+++ b/tests/test_data_store_clear_db.py
@@ -25,7 +25,6 @@ class DataStoreClearContentsPostGISDBTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_postgres_clear_db_contents(self):
         """Test whether all database tables are empty"""
         if self.store is None:
@@ -93,6 +92,7 @@ class DataStoreClearContentsSpatiaLiteTestCase(TestCase):
         self.assertEqual(len(records), 0)
 
 
+@pytest.mark.postgres
 class DataStoreClearSchemaPostGISTestCase(TestCase):
     def setUp(self):
         self.store = None
@@ -109,7 +109,6 @@ class DataStoreClearSchemaPostGISTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_clear_db_schema(self):
         if self.store is None:
             self.skipTest("Postgres is not available. Test is skipping")

--- a/tests/test_data_store_export_datafile.py
+++ b/tests/test_data_store_export_datafile.py
@@ -12,6 +12,7 @@ CURRENT_DIR = os.getcwd()
 DATA_PATH = os.path.join(FILE_PATH, "sample_data/track_files/rep_data/rep_test1.rep")
 
 
+@pytest.mark.postgres
 class DataStoreExportPostGISDBTestCase(unittest.TestCase):
     def setUp(self):
         self.path = os.path.join(CURRENT_DIR, "export_test.rep")
@@ -31,7 +32,6 @@ class DataStoreExportPostGISDBTestCase(unittest.TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_postgres_export_datafile(self):
         if self.store is None:
             self.skipTest("Postgres is not available. Test is skipping")

--- a/tests/test_data_store_export_datafile.py
+++ b/tests/test_data_store_export_datafile.py
@@ -31,6 +31,7 @@ class DataStoreExportPostGISDBTestCase(unittest.TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_postgres_export_datafile(self):
         if self.store is None:
             self.skipTest("Postgres is not available. Test is skipping")

--- a/tests/test_data_store_initialise.py
+++ b/tests/test_data_store_initialise.py
@@ -9,6 +9,7 @@ from testing.postgresql import Postgresql
 from pepys_import.core.store.data_store import DataStore
 
 
+@pytest.mark.postgres
 class DataStoreInitialisePostGISTestCase(TestCase):
     def setUp(self):
         self.store = None
@@ -25,7 +26,6 @@ class DataStoreInitialisePostGISTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_postgres_initialise(self):
         """Test whether schemas created successfully on PostgresSQL"""
         if self.store is None:
@@ -72,7 +72,6 @@ class DataStoreInitialisePostGISTestCase(TestCase):
         self.assertEqual(len(table_names), 1)
         self.assertIn("spatial_ref_sys", table_names)
 
-    @pytest.mark.postgres
     def test_is_schema_created(self):
         if self.store is None:
             self.skipTest("Postgres is not available. Test is skipping")

--- a/tests/test_data_store_initialise.py
+++ b/tests/test_data_store_initialise.py
@@ -2,6 +2,7 @@ import platform
 import unittest
 from unittest import TestCase
 
+import pytest
 from sqlalchemy import inspect
 from testing.postgresql import Postgresql
 
@@ -24,6 +25,7 @@ class DataStoreInitialisePostGISTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_postgres_initialise(self):
         """Test whether schemas created successfully on PostgresSQL"""
         if self.store is None:
@@ -70,6 +72,7 @@ class DataStoreInitialisePostGISTestCase(TestCase):
         self.assertEqual(len(table_names), 1)
         self.assertIn("spatial_ref_sys", table_names)
 
+    @pytest.mark.postgres
     def test_is_schema_created(self):
         if self.store is None:
             self.skipTest("Postgres is not available. Test is skipping")

--- a/tests/test_data_store_populate.py
+++ b/tests/test_data_store_populate.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from io import StringIO
 from unittest import TestCase
 
+import pytest
 from sqlalchemy.exc import OperationalError
 from testing.postgresql import Postgresql
 
@@ -219,6 +220,7 @@ class DataStorePopulatePostGISTestCase(TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_populate_reference(self):
         """Test whether CSVs successfully imported to PostGIS"""
 
@@ -249,6 +251,7 @@ class DataStorePopulatePostGISTestCase(TestCase):
             self.assertIn(nationality_object.name, "UNITED KINGDOM")
             self.assertIn(platform_type_object.name, "TTYPE-1")
 
+    @pytest.mark.postgres
     def test_populate_metadata(self):
         # reference tables must be filled first
         with self.store.session_scope():
@@ -329,6 +332,7 @@ class DataStorePopulatePostGISTestCase(TestCase):
             )
             self.assertEqual(sensor_type.name, "SENSOR-TYPE-1")
 
+    @pytest.mark.postgres
     def test_populate_measurement(self):
         # reference and metadata tables must be filled first
         with self.store.session_scope():

--- a/tests/test_data_store_populate.py
+++ b/tests/test_data_store_populate.py
@@ -190,6 +190,7 @@ class DataStorePopulateSpatiaLiteTestCase(TestCase):
             self.assertEqual(sensor.name, "SENSOR-1")
 
 
+@pytest.mark.postgres
 class DataStorePopulatePostGISTestCase(TestCase):
     def setUp(self) -> None:
         self.postgres = None
@@ -220,7 +221,6 @@ class DataStorePopulatePostGISTestCase(TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_populate_reference(self):
         """Test whether CSVs successfully imported to PostGIS"""
 
@@ -251,7 +251,6 @@ class DataStorePopulatePostGISTestCase(TestCase):
             self.assertIn(nationality_object.name, "UNITED KINGDOM")
             self.assertIn(platform_type_object.name, "TTYPE-1")
 
-    @pytest.mark.postgres
     def test_populate_metadata(self):
         # reference tables must be filled first
         with self.store.session_scope():
@@ -332,7 +331,6 @@ class DataStorePopulatePostGISTestCase(TestCase):
             )
             self.assertEqual(sensor_type.name, "SENSOR-TYPE-1")
 
-    @pytest.mark.postgres
     def test_populate_measurement(self):
         # reference and metadata tables must be filled first
         with self.store.session_scope():

--- a/tests/test_importers_postgis.py
+++ b/tests/test_importers_postgis.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+import pytest
 from sqlalchemy.exc import OperationalError
 from testing.postgresql import Postgresql
 
@@ -44,6 +45,7 @@ class SampleImporterTestCase(unittest.TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_process_folders_not_descending(self):
         """Test whether single level processing works for the given path"""
         processor = FileProcessor("single_level.db", archive=False)
@@ -61,6 +63,7 @@ class SampleImporterTestCase(unittest.TestCase):
         # now good one
         processor.process(DATA_PATH, self.store, False)
 
+    @pytest.mark.postgres
     def test_process_folders_descending(self):
         """Test whether descending processing works for the given path"""
         processor = FileProcessor("descending.db", archive=False)

--- a/tests/test_importers_postgis.py
+++ b/tests/test_importers_postgis.py
@@ -15,6 +15,7 @@ DATA_PATH = os.path.join(FILE_PATH, "sample_data")
 OUTPUT_PATH = os.path.join(DATA_PATH, "output")
 
 
+@pytest.mark.postgres
 class SampleImporterTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.postgres = None
@@ -45,7 +46,6 @@ class SampleImporterTestCase(unittest.TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_process_folders_not_descending(self):
         """Test whether single level processing works for the given path"""
         processor = FileProcessor("single_level.db", archive=False)
@@ -63,7 +63,6 @@ class SampleImporterTestCase(unittest.TestCase):
         # now good one
         processor.process(DATA_PATH, self.store, False)
 
-    @pytest.mark.postgres
     def test_process_folders_descending(self):
         """Test whether descending processing works for the given path"""
         processor = FileProcessor("descending.db", archive=False)

--- a/tests/test_spatial_data.py
+++ b/tests/test_spatial_data.py
@@ -65,6 +65,7 @@ class SpatialDataSpatialiteTestCase(unittest.TestCase):
             self.assertIsNone(first_state)
 
 
+@pytest.mark.postgres
 class SpatialDataPostGISTestCase(unittest.TestCase):
     def setUp(self):
         self.postgres = None
@@ -99,7 +100,6 @@ class SpatialDataPostGISTestCase(unittest.TestCase):
         except AttributeError:
             return
 
-    @pytest.mark.postgres
     def test_location(self):
         """Test location saved as Geo Point and it is possible to filter State objects on PostGIS"""
         if self.postgres is None:
@@ -124,7 +124,6 @@ class SpatialDataPostGISTestCase(unittest.TestCase):
 
             assert first_state.location == correct_loc
 
-    @pytest.mark.postgres
     def test_non_existing_location(self):
         """Test filtering State objects by non existing point returns None on PostGIS"""
 

--- a/tests/test_spatial_data.py
+++ b/tests/test_spatial_data.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+import pytest
 from geoalchemy2 import WKTElement
 from sqlalchemy import func
 from sqlalchemy.exc import OperationalError
@@ -98,6 +99,7 @@ class SpatialDataPostGISTestCase(unittest.TestCase):
         except AttributeError:
             return
 
+    @pytest.mark.postgres
     def test_location(self):
         """Test location saved as Geo Point and it is possible to filter State objects on PostGIS"""
         if self.postgres is None:
@@ -122,6 +124,7 @@ class SpatialDataPostGISTestCase(unittest.TestCase):
 
             assert first_state.location == correct_loc
 
+    @pytest.mark.postgres
     def test_non_existing_location(self):
         """Test filtering State objects by non existing point returns None on PostGIS"""
 


### PR DESCRIPTION
 - Added a `pytest.ini` configuration file to specify a 'custom mark' of `postgres`
 - Marked all tests that require postgres with `@pytest.mark.postgres`


To run all tests *except* the Postgres tests, run:

```
pytest tests/ -m "not postgres"
```

To run just the Postgres tests, run:

```
pytest tests/ -m postgres
```