### PR TITLE
Hotfix/Accept strings instead of DB objects in default resolver

### DIFF
--- a/pepys_import/resolvers/default_resolver.py
+++ b/pepys_import/resolvers/default_resolver.py
@@ -22,23 +22,20 @@ class DefaultResolver(DataResolver):
         if not platform_name:
             platform_name = self.default_platform_name
 
-        if not platform_type:
-            platform_type = data_store.search_platform_type(self.default_platform_type)
-            if not platform_type:
-                platform_type = data_store.add_to_platform_types(
-                    self.default_platform_type, change_id
-                )
+        if platform_type:
+            platform_type = data_store.add_to_platform_types(platform_type, change_id)
+        else:
+            platform_type = data_store.add_to_platform_types(self.default_platform_type, change_id)
 
-        if not nationality:
-            nationality = data_store.search_nationality(self.default_nationality)
-            if not nationality:
-                nationality = data_store.add_to_nationalities(self.default_nationality, change_id)
+        if nationality:
+            nationality = data_store.add_to_nationalities(nationality, change_id)
+        else:
+            nationality = data_store.add_to_nationalities(self.default_nationality, change_id)
 
-        if not privacy:
-            privacy = data_store.search_privacy(self.default_privacy)
-            if not privacy:
-                privacy = data_store.add_to_privacies(self.default_privacy, change_id)
-
+        if privacy:
+            privacy = data_store.add_to_privacies(privacy, change_id)
+        else:
+            privacy = data_store.add_to_privacies(self.default_privacy, change_id)
         return (
             platform_name,
             self.default_trigraph,
@@ -55,13 +52,15 @@ class DefaultResolver(DataResolver):
         if not sensor_name:
             sensor_name = self.default_sensor_name
 
-        if not sensor_type:
-            sensor_type = data_store.search_sensor_type(self.default_sensor_type)
-            if not sensor_type:
-                sensor_type = data_store.add_to_sensor_types(self.default_sensor_type, change_id)
+        if sensor_type:
+            sensor_type = data_store.add_to_sensor_types(sensor_type, change_id)
+        else:
+            sensor_type = data_store.add_to_sensor_types(self.default_sensor_type, change_id)
 
-        if not privacy:
-            privacy = self.resolve_privacy(data_store, change_id)
+        if privacy:
+            privacy = data_store.add_to_privacies(privacy, change_id)
+        else:
+            privacy = data_store.add_to_privacies(self.default_privacy, change_id)
 
         return sensor_name, sensor_type, privacy
 
@@ -78,12 +77,14 @@ class DefaultResolver(DataResolver):
         if not datafile_name:
             datafile_name = self.default_datafile_name
 
-        datafile_type = data_store.search_datafile_type(self.default_datafile_type)
-        if not datafile_type:
+        if datafile_type:
+            datafile_type = data_store.add_to_datafile_types(datafile_type, change_id)
+        else:
             datafile_type = data_store.add_to_datafile_types(self.default_datafile_type, change_id)
 
-        privacy = data_store.search_privacy(self.default_privacy)
-        if not privacy:
+        if privacy:
+            privacy = data_store.add_to_privacies(privacy, change_id)
+        else:
             privacy = data_store.add_to_privacies(self.default_privacy, change_id)
 
         return datafile_name, datafile_type, privacy

--- a/tests/test_basic_validator.py
+++ b/tests/test_basic_validator.py
@@ -20,7 +20,7 @@ class BasicValidatorTestCase(unittest.TestCase):
             change_id = self.store.add_to_changes("TEST", self.current_time, "TEST").change_id
             nationality = self.store.add_to_nationalities("test_nationality", change_id).name
             platform_type = self.store.add_to_platform_types("test_platform_type", change_id).name
-            sensor_type = self.store.add_to_sensor_types("test_sensor_type", change_id)
+            sensor_type = self.store.add_to_sensor_types("test_sensor_type", change_id).name
             privacy = self.store.add_to_privacies("test_privacy", change_id).name
 
             self.platform = self.store.get_platform(

--- a/tests/test_data_store_api_postgis.py
+++ b/tests/test_data_store_api_postgis.py
@@ -646,7 +646,7 @@ class SensorTestCase(TestCase):
                 ).name
                 self.sensor_type = self.store.add_to_sensor_types(
                     "test_sensor_type", self.change_id
-                )
+                ).name
                 self.privacy = self.store.add_to_privacies("test_privacy", self.change_id).name
 
                 self.platform = self.store.get_platform(
@@ -657,7 +657,6 @@ class SensorTestCase(TestCase):
                     change_id=self.change_id,
                 )
                 self.store.session.expunge(self.platform)
-                self.store.session.expunge(self.sensor_type)
         except OperationalError:
             print("Database schema and data population failed! Test is skipping.")
 
@@ -784,7 +783,7 @@ class MeasurementsTestCase(TestCase):
                 ).name
                 self.sensor_type = self.store.add_to_sensor_types(
                     "test_sensor_type", self.change_id
-                )
+                ).name
                 self.privacy = self.store.add_to_privacies("test_privacy", self.change_id).name
 
                 self.platform = self.store.get_platform(

--- a/tests/test_data_store_api_spatialite.py
+++ b/tests/test_data_store_api_spatialite.py
@@ -519,7 +519,9 @@ class SensorTestCase(TestCase):
             self.platform_type = self.store.add_to_platform_types(
                 "test_platform_type", self.change_id
             ).name
-            self.sensor_type = self.store.add_to_sensor_types("test_sensor_type", self.change_id)
+            self.sensor_type = self.store.add_to_sensor_types(
+                "test_sensor_type", self.change_id
+            ).name
             self.privacy = self.store.add_to_privacies("test_privacy", self.change_id).name
 
             self.platform = self.store.get_platform(
@@ -530,7 +532,6 @@ class SensorTestCase(TestCase):
                 change_id=self.change_id,
             )
             self.store.session.expunge(self.platform)
-            self.store.session.expunge(self.sensor_type)
 
     def tearDown(self):
         pass
@@ -624,7 +625,9 @@ class MeasurementsTestCase(TestCase):
             self.platform_type = self.store.add_to_platform_types(
                 "test_platform_type", self.change_id
             ).name
-            self.sensor_type = self.store.add_to_sensor_types("test_sensor_type", self.change_id)
+            self.sensor_type = self.store.add_to_sensor_types(
+                "test_sensor_type", self.change_id
+            ).name
             self.privacy = self.store.add_to_privacies("test_privacy", self.change_id).name
 
             self.platform = self.store.get_platform(
@@ -644,7 +647,6 @@ class MeasurementsTestCase(TestCase):
             self.store.session.expunge(self.platform)
             self.store.session.expunge(self.file)
             self.store.session.expunge(self.comment_type)
-            self.store.session.expunge(self.sensor_type)
 
         class TestParser(Importer):
             def __init__(

--- a/tests/test_enhanced_validator.py
+++ b/tests/test_enhanced_validator.py
@@ -21,7 +21,7 @@ class EnhancedValidatorTestCase(unittest.TestCase):
             platform_type = self.store.add_to_platform_types(
                 "test_platform_type", self.change_id
             ).name
-            sensor_type = self.store.add_to_sensor_types("test_sensor_type", self.change_id)
+            sensor_type = self.store.add_to_sensor_types("test_sensor_type", self.change_id).name
             privacy = self.store.add_to_privacies("test_privacy", self.change_id).name
 
             self.platform = self.store.get_platform(

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1018,7 +1018,9 @@ class TestLocationRoundtripToDB(unittest.TestCase):
             self.platform_type = self.store.add_to_platform_types(
                 "test_platform_type", self.change_id
             ).name
-            self.sensor_type = self.store.add_to_sensor_types("test_sensor_type", self.change_id)
+            self.sensor_type = self.store.add_to_sensor_types(
+                "test_sensor_type", self.change_id
+            ).name
             self.privacy = self.store.add_to_privacies("test_privacy", self.change_id).name
 
             self.platform = self.store.get_platform(
@@ -1040,7 +1042,6 @@ class TestLocationRoundtripToDB(unittest.TestCase):
             self.store.session.expunge(self.sensor)
             self.store.session.expunge(self.platform)
             self.store.session.expunge(self.file)
-            self.store.session.expunge(self.sensor_type)
 
         class TestParser(Importer):
             def __init__(


### PR DESCRIPTION
In this PR, the behavior of Default Resolver has been changed. It follows the same strategy with the Command Line Resolver now. For checking the main differences of the PR, you can look at https://github.com/debrief/pepys-import/blob/91de2e4923da11f79d03494077706f99a377b436/pepys_import/core/store/data_store.py#L723-L767 
and [default_resolver.py](https://github.com/debrief/pepys-import/blob/91de2e4923da11f79d03494077706f99a377b436/pepys_import/resolvers/default_resolver.py).


**Note:** Caching DB objects were breaking imports. Therefore, I deleted them. It was causing the `object not bound to a Session` error.