### PR TITLE
Add ability to turn off recording of extractions in an importer

### DIFF
--- a/importers/replay_importer.py
+++ b/importers/replay_importer.py
@@ -15,6 +15,10 @@ class ReplayImporter(Importer):
         self.text_label = None
         self.depth = 0.0
 
+        # Example: Uncomment this line to turn off recording of extractions
+        # for this importer
+        # self.disable_recording()
+
     def can_load_this_type(self, suffix):
         return suffix.upper() == ".REP" or suffix.upper() == ".DSF"
 

--- a/pepys_import/file/highlighter/highlighter.py
+++ b/pepys_import/file/highlighter/highlighter.py
@@ -24,6 +24,9 @@ class HighlightedFile:
         self.dict_color = {}
         self.number_of_lines = number_of_lines
 
+        # List of importers to ignore record calls from
+        self.ignored_importers = []
+
     def chars_debug(self):
         """
         Debug method, to check contents of chars

--- a/pepys_import/file/highlighter/support/line.py
+++ b/pepys_import/file/highlighter/support/line.py
@@ -81,7 +81,8 @@ class Line:
         """
         Record a usage of the whole line
 
-        :param tool: Name of the importer handling the import (eg. "NMEA Importer")
+        :param tool: Name of the importer handling the import (eg. "NMEA Importer)
+                     Should be set to `self.name` when called from an importer
         :param field: The field that the token is being interpreted as (eg. "speed")
         :param value: The parsed value of the token (eg. "5 knots") - where possible,
                       pass a Quantity object with associated units
@@ -93,6 +94,11 @@ class Line:
         Adds a SingleUsage object to each of the relevant characters in the
         char array referenced by each SubToken child.
         """
+        # Don't record anything if the importer that called record
+        # has called 'disable_recording()`
+        if tool in self.highlighted_file.ignored_importers:
+            return
+
         self.highlighted_file.fill_char_array_if_needed()
 
         tool_field = tool + "/" + field

--- a/pepys_import/file/highlighter/support/token.py
+++ b/pepys_import/file/highlighter/support/token.py
@@ -78,7 +78,8 @@ class Token:
         """
         Record the usage of this token for a specific purpose
 
-        :param tool: Name of the importer handling the import (eg. "NMEA Importer")
+        :param tool: Name of the importer handling the import (eg. "NMEA Importer)
+                     Should be set to `self.name` when called from an importer
         :param field: The field that the token is being interpreted as (eg. "speed")
         :param value: The parsed value of the token (eg. "5 knots") - where possible,
                       pass a Quantity object with associated units
@@ -90,6 +91,11 @@ class Token:
         This adds SingleUsage objects to each of the relevant characters in the
         character array stored by the SubToken objects that are children of this object.
         """
+        # Don't record anything if the importer that called record
+        # has called 'disable_recording()`
+        if tool in self.highlighted_file.ignored_importers:
+            return
+
         self.highlighted_file.fill_char_array_if_needed()
 
         tool_field = tool + "/" + field

--- a/pepys_import/file/importer.py
+++ b/pepys_import/file/importer.py
@@ -13,8 +13,13 @@ class Importer(ABC):
         self.errors = None
         self.error_type = None
 
+        self.do_recording = True
+
     def __str__(self):
         return self.name
+
+    def disable_recording(self):
+        self.do_recording = False
 
     @abstractmethod
     def can_load_this_type(self, suffix) -> bool:
@@ -82,6 +87,12 @@ class Importer(ABC):
         self.errors = list()
         self.error_type = f"{self.short_name} - Parsing error on {basename}"
         datafile.measurements[self.short_name] = dict()
+
+        # If we've turned off recording of extractions for this importer
+        # then add this to the list of ignored importers for this HighlightedFile
+        # object
+        if not self.do_recording:
+            file_object.ignored_importers.append(self.name)
 
         # perform load
         self._load_this_file(data_store, path, file_object, datafile, change_id)

--- a/tests/highlighter_tests/test_recording.py
+++ b/tests/highlighter_tests/test_recording.py
@@ -139,6 +139,23 @@ class UsageRecordingTests(unittest.TestCase):
 
         data_file.export(os.path.join(OUTPUT_FOLDER, "track_lines.html"), True)
 
+    def test_ignored_importers(self):
+        data_file = HighlightedFile(DATA_FILE)
+
+        data_file.ignored_importers.append("Test Importer")
+
+        lines = data_file.lines()
+
+        lines[0].record("Test Importer", "Test", "Test")
+
+        tokens = lines[1].tokens()
+
+        tokens[0].record("Test Importer", "Test", "Test")
+
+        # Assert that no initialisation of the chars array took place
+        # and therefore the record calls did nothing
+        assert len(data_file.chars) == 0
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -285,6 +285,36 @@ class ImporterRemoveTestCase(unittest.TestCase):
         self.assertIn("Files got processed: 0 times", output)
 
 
+class ImporterDisableRecordingTest(unittest.TestCase):
+    def test_turn_off_recording(self):
+        class TestImporter(Importer):
+            def __init__(self):
+                super().__init__(
+                    name="Test Importer", validation_level=None, short_name="Test Importer"
+                )
+                self.disable_recording()
+
+            def can_load_this_header(self, header) -> bool:
+                return True
+
+            def can_load_this_filename(self, filename):
+                return True
+
+            def can_load_this_type(self, suffix):
+                return True
+
+            def can_load_this_file(self, file_contents):
+                return False
+
+            def _load_this_file(self, data_store, path, file_object, data_file):
+                assert file_object.ignored_importers == ["Test Importer"]
+
+        processor = FileProcessor()
+
+        processor.register_importer(TestImporter())
+        processor.process(DATA_PATH, None, False)
+
+
 class ReplayImporterTestCase(unittest.TestCase):
     def test_degrees_for(self):
         """Test whether the method correctly converts the given values to degree"""

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -304,9 +304,9 @@ class ImporterDisableRecordingTest(unittest.TestCase):
                 return True
 
             def can_load_this_file(self, file_contents):
-                return False
+                return True
 
-            def _load_this_file(self, data_store, path, file_object, data_file):
+            def _load_this_file(self, data_store, path, file_object, datafile, change_id):
                 assert file_object.ignored_importers == ["Test Importer"]
 
         processor = FileProcessor()


### PR DESCRIPTION
This allows you to leave the `record` calls in place (saves effort of removing them,
and means that you can easily turn them on again in the future if you need to) and have them
basically turn into a no-op. This will also speed up the processing of files that don't need
extractions recorded - as if the record calls are turned off, none of the intermediate representations will be created either.

Specifically, this involves:

 - A new method on the base Importer class called disable_recording() that can be called to turn off recording for that importer
 (it can be called from __init__ or even within an if statement in _load_this_file to make a decision based on the file name!)
 - A new attribute for HighlightedFile that keeps a list of importers to ignore for that file (so we can ignore just one of the
 three importers that operate on REP files for instance)
 - New logic in the record method for Line and Token objects to tell them to immediately return if the name of the importer in the record call
 matches the name of an importer they're told to ignore