### PR TITLE
Updated create_shortcuts script to create a Start Menu shortcut for pepys-admin

### DIFF
--- a/bin/create_shortcuts.ps1
+++ b/bin/create_shortcuts.ps1
@@ -2,6 +2,10 @@
 # Windows Scripting Host COM object
 $WshShell = New-Object -comObject WScript.Shell
 
+#
+# Add shortcuts to Send To folder
+#
+
 # Get the User's Send To folder location
 # This is safer than using a hard-coded PATH as network/user settings may mean the folder
 # is in an unexpected place
@@ -26,6 +30,22 @@ $Shortcut.Save()
 
 $Shortcut = $WshShell.CreateShortcut($sendto_location + "\Pepys Import (no archive).lnk")
 $Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_import_no_archive.bat")
+$Shortcut.IconLocation = $icon_string
+$Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
+$Shortcut.Save()
+
+#
+# Add shortcut to Start Menu
+#
+
+# Get the User's Start Menu folder
+$startmenu_location = "$env:USERPROFILE\Start Menu\Programs\"
+
+# Create Pepys folder in Start Menu
+New-Item -Path $startmenu_location -Name "Pepys" -ItemType "directory"
+
+$Shortcut = $WshShell.CreateShortcut($startmenu_location + "Pepys\Pepys Admin.lnk")
+$Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_admin.bat")
 $Shortcut.IconLocation = $icon_string
 $Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
 $Shortcut.Save()

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -1,5 +1,6 @@
 import cmd
 import os
+import sys
 from datetime import datetime
 
 from iterfzf import iterfzf
@@ -168,7 +169,7 @@ class AdminShell(cmd.Cmd):
     def do_exit():
         """Exit the application"""
         print("Thank you for using Pepys Admin")
-        exit()
+        sys.exit()
 
     def default(self, line):
         command, arg, line = self.parseline(line)


### PR DESCRIPTION
Start Menu shortcut is created in a Pepys folder, and called 'Pepys Admin'.

Also fixed a minor bug in the admin CLI that meant it crashed on exit: it seems that sys.exit() is the platform independent way to exit Python, rather than just exit().