### PR TITLE
Fix double-line spacing in REP export on Windows

### DIFF
--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -1325,7 +1325,7 @@ class DataStore:
                     depth_str,
                 ]
                 data = "\t".join(state_rep_line)
-                file.write(data + "\r\n")
+                file.write(data + "\n")
 
             # Export contacts
             for contact in contacts:
@@ -1359,7 +1359,7 @@ class DataStore:
                 else:
                     contact_rep_line.insert(0, ";SENSOR:")
                 data = "\t".join(contact_rep_line)
-                file.write(data + "\r\n")
+                file.write(data + "\n")
 
             # Export comments
             for comment in comments:
@@ -1381,7 +1381,7 @@ class DataStore:
                     comment_rep_line.insert(0, ";NARRATIVE2:")
 
                 data = "\t".join(comment_rep_line)
-                file.write(data + "\r\n")
+                file.write(data + "\n")
 
     def is_datafile_loaded_before(self, file_size, file_hash):
         """


### PR DESCRIPTION
Line endings were specified as `\r\n`. According to https://docs.python.org/3/library/os.html#os.linesep you should just use
`\n` on all platforms and Python will sort it out - so I've switched to that.

Tested and working on OS X and Windows.

Fixes #289 