### PR TITLE
Fix deployment issue with installing distlib - NEW

### DIFF
--- a/bin/pepys_admin.bat
+++ b/bin/pepys_admin.bat
@@ -1,0 +1,4 @@
+CALL set_paths.bat
+python -m pepys_admin.cli
+REM we're pausing the end of the script so we learn more about what is being processed
+PAUSE

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -54,6 +54,10 @@ Lib\site-packages
 
 Write-Output "INFO: Set Python pth file"
 
+# Install distlib manually from a wheel file, as creation of the wheel through a standard pip install
+# fails on embedded python
+.\python\python.exe -m pip install .\bin\distlib-0.3.0-py2.py3-none-any.whl
+
 # Do a standard pip install of the requirements and dev requirements, not warning us that scripts will be unavailable
 .\python\python.exe -m pip install -r requirements.txt -r requirements_dev.txt --no-warn-script-location
 
@@ -62,6 +66,7 @@ Write-Output "INFO: Installed Python dependencies"
 Remove-Item *.zip
 Remove-Item *.7z
 Remove-Item get-pip.py
+Remove-Item .\bin\distlib-0.3.0-py2.py3-none-any.whl
 
 Write-Output "INFO: Cleaned up all except 7zip"
 


### PR DESCRIPTION
distlib was failing to install when the create_deployment.ps1 script was run. This was traced to an issue with installing this package which occurs only when it is installed from an embedded Python installation - as opposed to a standard Python installation.

To solve this, we have added a wheel file for distlib to the repo, and this PR updates the deployment script to install from this wheel file, and then delete it (so it doesn't get zipped up for the output).