### PR TITLE
Allow deployment scripts to run multiple times without errors

### DIFF
--- a/bin/create_shortcuts.bat
+++ b/bin/create_shortcuts.bat
@@ -1,1 +1,4 @@
+@echo off
 powershell.exe -executionpolicy remotesigned -File create_shortcuts.ps1
+echo Shortcuts created
+PAUSE

--- a/bin/create_shortcuts.ps1
+++ b/bin/create_shortcuts.ps1
@@ -17,8 +17,15 @@ $sendto_location = $WshShell.SpecialFolders("SendTo")
 $icon_path = [System.IO.Path]::GetFullPath(".\favicon.ico")
 $icon_string = "$icon_path,0"
 
+#
+# Add Pepys Import shortcut to Send To
+#
 
-$Shortcut = $WshShell.CreateShortcut($sendto_location + "\Pepys Import.lnk")
+$shortcut_loc = $sendto_location + "\Pepys Import.lnk"
+
+if (Test-Path $shortcut_loc) { Remove-Item $shortcut_loc; }
+
+$Shortcut = $WshShell.CreateShortcut($shortcut_loc)
 # We need to use full paths here or the shortcut will assume everything is relative to
 # C:\
 $Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_import.bat")
@@ -28,7 +35,16 @@ $Shortcut.IconLocation = $icon_string
 $Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
 $Shortcut.Save()
 
-$Shortcut = $WshShell.CreateShortcut($sendto_location + "\Pepys Import (no archive).lnk")
+
+#
+# Add Pepys Import (no archive) shortcut to Send To
+#
+
+$shortcut_loc = $sendto_location + "\Pepys Import (no archive).lnk"
+
+if (Test-Path $shortcut_loc) { Remove-Item $shortcut_loc; }
+
+$Shortcut = $WshShell.CreateShortcut($shortcut_loc)
 $Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_import_no_archive.bat")
 $Shortcut.IconLocation = $icon_string
 $Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
@@ -40,6 +56,11 @@ $Shortcut.Save()
 
 # Get the User's Start Menu folder
 $startmenu_location = "$env:USERPROFILE\Start Menu\Programs\"
+
+# Delete Pepys folder in Start Menu if it exists
+$pepys_folder = $startmenu_location + "\Pepys"
+
+if (Test-Path $pepys_folder) { Remove-Item $pepys_folder -Recurse ; }
 
 # Create Pepys folder in Start Menu
 New-Item -Path $startmenu_location -Name "Pepys" -ItemType "directory"

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -5,7 +5,7 @@ $url = 'https://www.python.org/ftp/python/3.7.6/python-3.7.6-embed-amd64.zip'
 (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\python.zip")
 
 # Extract zip file
-Expand-Archive -Path python.zip -DestinationPath .\python
+Expand-Archive -Path python.zip -DestinationPath .\python -Force
 Write-Output "INFO: Downloaded and extracted embedded Python"
 
 # Download and run get-pip to install pip
@@ -34,10 +34,10 @@ $url = 'http://www.gaia-gis.it/gaia-sins/windows-bin-NEXTGEN-amd64/mod_spatialit
 $url = 'http://www.7-zip.org/a/7za920.zip'
 (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\7zip.zip")
 # Put the 7zip exe in the .\7zip folder - we will delete this later
-Expand-Archive -Path 7zip.zip -DestinationPath .\7zip
+Expand-Archive -Path 7zip.zip -DestinationPath .\7zip -Force
 
 # Extract the mod_spatialite 7zip file into the lib folder (it creates its own subfolder in there)
-.\7zip\7za.exe x .\mod_spatialite.7z -olib
+.\7zip\7za.exe x .\mod_spatialite.7z -olib -y
 
 Write-Output "INFO: Downloaded and extracted mod_spatialite"
 

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -66,7 +66,6 @@ Write-Output "INFO: Installed Python dependencies"
 Remove-Item *.zip
 Remove-Item *.7z
 Remove-Item get-pip.py
-Remove-Item .\bin\distlib-0.3.0-py2.py3-none-any.whl
 
 Write-Output "INFO: Cleaned up all except 7zip"
 
@@ -74,7 +73,7 @@ Write-Output "INFO: Cleaned up all except 7zip"
 # excluding the 7zip folder
 $date_str = Get-Date -Format "yyyyMMdd"
 $output_filename = $date_str + "_pepys-import.zip"
-.\7zip\7za.exe a .\$output_filename .\* -xr!7zip/
+.\7zip\7za.exe a .\$output_filename .\* -xr!7zip/ -xr!"bin\distlib-0.3.0-py2.py3-none-any.whl"
 
 Write-Output "INFO: Written zipped deployment file to $output_filename"
 


### PR DESCRIPTION
This PR allows the deployment scripts (`create_deployment.ps1` and `create_shortcuts.ps1`) to be run multiple times in succession without raising errors. Specifically, this means:

 - All zip extractions now happen with a parameter to force overwriting existing files, so we don't get errors saying files already exist
 - The distlib wheel file is no longer deleted (as it wouldn't be there for the next run), but is just excluded from the zip file instead
 - The script for creating shortcuts now deletes the shortcuts first (if they exist) and then creates them

I've also tidied up the create_shortcuts script, so it prints a message saying it's finished, and waits for the user to press a key.

Fixes #306 