### PR TITLE
Hotfix - Fixes errors with running isort through pre-commit

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 100
+known_third_party =dateutil,geoalchemy2,iterfzf,lxml,pint,prompt_toolkit,pyfiglet,pytest,setuptools,shapely,sqlalchemy,tabulate,testing,tqdm

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,13 @@
-repos:
   - repo: https://github.com/python/black
     rev: stable
     hooks:
       - id: black
         language_version: python3.7
-  - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v2.1.0
     hooks:
-      - id: isort
-        additional_dependencies: [toml]
+    -   id: seed-isort-config
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21  # pick the isort version you'd like to use from https://github.com/timothycrosley/isort/releases
+    hooks:
+    -   id: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,3 @@
 [tool.black]
 line-length = 100
 target-version = ['py37']
-
-[tool.isort]
-multi_line_output = 3  # Vertical Hanging Indent, which is supported by Black
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 100


### PR DESCRIPTION
This PR changes two things:

1. Moves the isort config from pyproject.toml to .isort.cfg. For some reason, isort often doesn't find the config when it's in pyproject.toml.

2. Adds an extra task to the pre-commit config that works out what modules are third party (ie. installed from pip etc), and adds those to a configuration
option in the .isort.cfg file. This will 'fail' and update the .isort.cfg file every time we use a new module from pip, but that shouldn't be a problem - just commit the updated .isort.cfg.
