### PR TITLE
Add overall exception handlers to catch SQLAlchemy exceptions

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 100
-known_third_party =dateutil,geoalchemy2,iterfzf,lxml,pint,prompt_toolkit,pyfiglet,pytest,setuptools,shapely,sqlalchemy,tabulate,testing,tqdm
+known_third_party =dateutil,geoalchemy2,iterfzf,lxml,pg8000,pint,prompt_toolkit,pyfiglet,pytest,setuptools,shapely,sqlalchemy,tabulate,testing,tqdm

--- a/bin/pepys_import.bat
+++ b/bin/pepys_import.bat
@@ -1,5 +1,5 @@
 CALL set_paths.bat
 REM note: when we're called via the "SendTo" link, the target is in the first argument
-python -m pepys_import.import --archive --path %1 %2 %3 %4 %5 %6 %7 %8
+python -m pepys_import.cli--archive --path %1 %2 %3 %4 %5 %6 %7 %8
 REM we're pausing the end of the script so we learn more about what is being processed
 PAUSE

--- a/bin/pepys_import_no_archive.bat
+++ b/bin/pepys_import_no_archive.bat
@@ -1,5 +1,5 @@
 CALL set_paths.bat
 REM note: when we're called via the "SendTo" link, the target is in the first argument
-python -m pepys_import.import --path %1 %2 %3 %4 %5 %6 %7 %8
+python -m pepys_import.cli --path %1 %2 %3 %4 %5 %6 %7 %8
 REM we're pausing the end of the script so we learn more about what is being processed
 PAUSE

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -103,7 +103,7 @@ and run the following:
 
 .. code-block:: none
 
-    python -m pepys_import.import --path .\track_files_test\rep_data\rep_test1_bad.rep --resolver default --archive
+    python -m pepys_import.cli --path .\track_files_test\rep_data\rep_test1_bad.rep --resolver default --archive
 
 This will run the Pepys Import command, telling it to import the :code:`rep_test1_bad.rep` file with
 the default resolver (so it doesn't ask you questions during import) and telling it to archive the file
@@ -148,7 +148,7 @@ Try importing the file again, using exactly the same command as before:
 
 .. code-block:: none
 
-    python -m pepys_import.import --path .\track_files_test\rep_data\rep_test1_bad.rep --resolver default --archive
+    python -m pepys_import.cli --path .\track_files_test\rep_data\rep_test1_bad.rep --resolver default --archive
 
 Now, if you look in the :code:`sources` directory under :code:`archive`, you will find a copy of the
 file that was imported - and this file will have been deleted from its original location.

--- a/docs/pepys_import.rst
+++ b/docs/pepys_import.rst
@@ -18,7 +18,7 @@ Submodules
 pepys\_import.import module
 ---------------------------
 
-.. automodule:: pepys_import.import
+.. automodule:: pepys_import.cli
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -12,7 +12,7 @@ in two ways:
    file you want to import, and choose either :code:`Pepys Import` to import using the default settings
    or :code:`Pepys Import (no archive)` to import without archiving the imported files.
 
- - **Manually:** Run :code:`python -m pepys_import.import <options>` on the command-line, ensuring that the `python`
+ - **Manually:** Run :code:`python -m pepys_import.cli <options>` on the command-line, ensuring that the `python`
    executable on your PATH is the one for which pepys-import has been installed.
 
 Command-line options
@@ -20,7 +20,7 @@ Command-line options
 
 .. code-block:: none
 
-  usage: import.py [-h] [--path PATH] [--archive] [--db DB]
+  usage: cli.py [-h] [--path PATH] [--archive] [--db DB]
                   [--resolver RESOLVER]
 
   optional arguments:

--- a/pepys_admin/cli.py
+++ b/pepys_admin/cli.py
@@ -40,7 +40,11 @@ def main():
 
     try:
         AdminShell(data_store, args.path).cmdloop()
-    except sqlalchemy.exc.ProgrammingError as e:
+    except (
+        sqlalchemy.exc.ProgrammingError,
+        sqlalchemy.exc.OperationalError,
+        sqlalchemy.exc.InvalidRequestError,
+    ) as e:
         print(
             f"SQL Exception details: {e}\n\n"
             "ERROR: SQL error when communicating with database\n"

--- a/pepys_admin/cli.py
+++ b/pepys_admin/cli.py
@@ -1,5 +1,7 @@
 import argparse
 
+import sqlalchemy
+
 from config import DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_TYPE, DB_USERNAME
 from pepys_admin.admin_cli import AdminShell
 from pepys_import.core.store.data_store import DataStore
@@ -36,7 +38,16 @@ def main():
             welcome_text="Pepys_admin",
         )
 
-    AdminShell(data_store, args.path).cmdloop()
+    try:
+        AdminShell(data_store, args.path).cmdloop()
+    except sqlalchemy.exc.ProgrammingError as e:
+        print(
+            f"SQL Exception details: {e}\n\n"
+            "ERROR: SQL error when communicating with database\n"
+            "Please check your database structure is up-to-date with that expected "
+            "by the version of Pepys you have installed.\n"
+            "See above for the full error from SQLAlchemy."
+        )
 
 
 if __name__ == "__main__":

--- a/pepys_admin/cli.py
+++ b/pepys_admin/cli.py
@@ -38,8 +38,12 @@ def main():
             welcome_text="Pepys_admin",
         )
 
+    run_admin_shell(data_store, args.path)
+
+
+def run_admin_shell(data_store, path):
     try:
-        AdminShell(data_store, args.path).cmdloop()
+        AdminShell(data_store, path).cmdloop()
     except (
         sqlalchemy.exc.ProgrammingError,
         sqlalchemy.exc.OperationalError,

--- a/pepys_import/cli.py
+++ b/pepys_import/cli.py
@@ -57,6 +57,16 @@ def process(path=DIRECTORY_PATH, archive=False, db=None, resolver="command-line"
             db_type=DB_TYPE,
             missing_data_resolver=resolver_obj,
         )
+    elif type(db) is dict:
+        data_store = DataStore(
+            db_username=db["username"],
+            db_password=db["password"],
+            db_host=db["host"],
+            db_port=db["port"],
+            db_name=db["name"],
+            db_type=db["type"],
+            missing_data_resolver=resolver_obj,
+        )
     else:
         data_store = DataStore(
             db_username="",
@@ -78,7 +88,11 @@ def process(path=DIRECTORY_PATH, archive=False, db=None, resolver="command-line"
 
     try:
         processor.process(path, data_store, True)
-    except sqlalchemy.exc.ProgrammingError as e:
+    except (
+        sqlalchemy.exc.ProgrammingError,
+        sqlalchemy.exc.OperationalError,
+        sqlalchemy.exc.InvalidRequestError,
+    ) as e:
         print(
             f"SQL Exception details: {e}\n\n"
             "ERROR: SQL error when communicating with database\n"

--- a/pepys_import/import.py
+++ b/pepys_import/import.py
@@ -1,6 +1,8 @@
 import argparse
 import os
 
+import sqlalchemy
+
 from config import DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_TYPE, DB_USERNAME
 from pepys_import.core.store.data_store import DataStore
 from pepys_import.file.file_processor import FileProcessor
@@ -73,7 +75,17 @@ def process(path=DIRECTORY_PATH, archive=False, db=None, resolver="command-line"
 
     processor = FileProcessor(archive=archive)
     processor.load_importers_dynamically()
-    processor.process(path, data_store, True)
+
+    try:
+        processor.process(path, data_store, True)
+    except sqlalchemy.exc.ProgrammingError as e:
+        print(
+            f"SQL Exception details: {e}\n\n"
+            "ERROR: SQL error when communicating with database\n"
+            "Please check your database structure is up-to-date with that expected "
+            "by the version of Pepys you have installed.\n"
+            "See above for the full error from SQLAlchemy."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_admin_cli.py
+++ b/tests/test_admin_cli.py
@@ -1,17 +1,23 @@
 import os
 import shutil
+import sqlite3
 import unittest
 from contextlib import redirect_stdout
 from io import StringIO
+from sqlite3 import OperationalError
 from unittest.mock import patch
 
+import pg8000
 import pytest
+from testing.postgresql import Postgresql
 
 from pepys_admin.admin_cli import AdminShell
+from pepys_admin.cli import run_admin_shell
 from pepys_admin.export_by_platform_cli import ExportByPlatformNameShell
 from pepys_admin.initialise_cli import InitialiseShell
 from pepys_import.core.store.data_store import DataStore
 from pepys_import.file.file_processor import FileProcessor
+from pepys_import.utils.geoalchemy_utils import load_spatialite
 
 FILE_PATH = os.path.dirname(__file__)
 CURRENT_DIR = os.getcwd()
@@ -538,6 +544,106 @@ class ExportByPlatformNameShellTestCase(unittest.TestCase):
             self.shell.postcmd(stop=False, line="123456789")
         output = temp_output.getvalue()
         assert self.shell.intro in output
+
+
+class AdminCLIMissingDBColumnTestCaseSQLite(unittest.TestCase):
+    def setUp(self):
+        ds = DataStore("", "", "", 0, "cli_import_test.db", db_type="sqlite")
+        ds.initialise()
+
+    def tearDown(self):
+        os.remove("cli_import_test.db")
+
+    @patch("cmd.input", return_value="2\n")
+    def test_missing_db_column_sqlite(self, patched_input):
+        conn = sqlite3.connect("cli_import_test.db")
+        load_spatialite(conn, None)
+
+        # We want to DROP a column from the States table, but SQLite doesn't support this
+        # so we drop the table and create a new table instead
+        conn.execute("DROP TABLE States")
+
+        # SQL to create a States table without a heading column
+        create_sql = """CREATE TABLE States (
+        state_id INTEGER NOT NULL, 
+        time TIMESTAMP NOT NULL, 
+        sensor_id INTEGER NOT NULL, 
+        elevation REAL, 
+        course REAL, 
+        speed REAL, 
+        source_id INTEGER NOT NULL, 
+        privacy_id INTEGER, 
+        created_date DATETIME, "location" POINT, 
+        PRIMARY KEY (state_id)
+        )"""
+
+        conn.execute(create_sql)
+        conn.close()
+
+        temp_output = StringIO()
+        with redirect_stdout(temp_output):
+            data_store = DataStore("", "", "", 0, "cli_import_test.db", db_type="sqlite")
+            run_admin_shell(data_store, ".")
+        output = temp_output.getvalue()
+
+        assert "ERROR: SQL error when communicating with database" in output
+
+
+@pytest.mark.postgres
+class TestAdminCLIWithMissingDBFieldPostgres(unittest.TestCase):
+    def setUp(self):
+        self.postgres = None
+        self.store = None
+        try:
+            self.postgres = Postgresql(
+                database="test", host="localhost", user="postgres", password="postgres", port=55527,
+            )
+        except RuntimeError:
+            print("PostgreSQL database couldn't be created! Test is skipping.")
+            return
+        try:
+            self.store = DataStore(
+                db_name="test",
+                db_host="localhost",
+                db_username="postgres",
+                db_password="postgres",
+                db_port=55527,
+                db_type="postgres",
+            )
+            self.store.initialise()
+        except OperationalError:
+            print("Database schema and data population failed! Test is skipping.")
+
+    def tearDown(self):
+        try:
+            self.postgres.stop()
+        except AttributeError:
+            return
+
+    @patch("cmd.input", return_value="2\n")
+    def test_missing_db_column_postgres(self, patched_input):
+        conn = pg8000.connect(user="postgres", password="postgres", database="test", port=55527)
+        cursor = conn.cursor()
+        # Alter table to drop heading column
+        cursor.execute('ALTER TABLE pepys."States" DROP COLUMN heading CASCADE;')
+
+        conn.commit()
+        conn.close()
+
+        temp_output = StringIO()
+        with redirect_stdout(temp_output):
+            data_store = DataStore(
+                db_name="test",
+                db_host="localhost",
+                db_username="postgres",
+                db_password="postgres",
+                db_port=55527,
+                db_type="postgres",
+            )
+            run_admin_shell(data_store, ".")
+        output = temp_output.getvalue()
+
+        assert "ERROR: SQL error when communicating with database" in output
 
 
 if __name__ == "__main__":

--- a/tests/test_import_cli.py
+++ b/tests/test_import_cli.py
@@ -1,0 +1,174 @@
+import os
+import sqlite3
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from sqlite3 import OperationalError
+
+import pg8000
+import pytest
+from testing.postgresql import Postgresql
+
+from pepys_import.cli import process
+from pepys_import.core.store.data_store import DataStore
+from pepys_import.utils.geoalchemy_utils import load_spatialite
+
+FILE_PATH = os.path.dirname(__file__)
+DATA_PATH = os.path.join(FILE_PATH, "sample_data/track_files/other_data")
+
+
+class TestImportWithMissingDBFieldSQLite(unittest.TestCase):
+    def setUp(self):
+        ds = DataStore("", "", "", 0, "cli_import_test.db", db_type="sqlite")
+        ds.initialise()
+
+    def tearDown(self):
+        os.remove("cli_import_test.db")
+
+    def test_import_with_missing_db_field(self):
+        conn = sqlite3.connect("cli_import_test.db")
+        load_spatialite(conn, None)
+
+        # We want to DROP a column from the States table, but SQLite doesn't support this
+        # so we drop the table and create a new table instead
+        conn.execute("DROP TABLE States")
+
+        # SQL to create a States table without a heading column
+        create_sql = """CREATE TABLE States (
+        state_id INTEGER NOT NULL, 
+        time TIMESTAMP NOT NULL, 
+        sensor_id INTEGER NOT NULL, 
+        elevation REAL, 
+        course REAL, 
+        speed REAL, 
+        source_id INTEGER NOT NULL, 
+        privacy_id INTEGER, 
+        created_date DATETIME, "location" POINT, 
+        PRIMARY KEY (state_id)
+        )"""
+
+        conn.execute(create_sql)
+        conn.close()
+
+        temp_output = StringIO()
+        with redirect_stdout(temp_output):
+            process(path=DATA_PATH, archive=False, db="cli_import_test.db", resolver="default")
+        output = temp_output.getvalue()
+
+        assert "ERROR: SQL error when communicating with database" in output
+
+
+@pytest.mark.postgres
+class TestImportWithMissingDBFieldPostgres(unittest.TestCase):
+    def setUp(self):
+        self.postgres = None
+        self.store = None
+        try:
+            self.postgres = Postgresql(
+                database="test", host="localhost", user="postgres", password="postgres", port=55527,
+            )
+        except RuntimeError:
+            print("PostgreSQL database couldn't be created! Test is skipping.")
+            return
+        try:
+            self.store = DataStore(
+                db_name="test",
+                db_host="localhost",
+                db_username="postgres",
+                db_password="postgres",
+                db_port=55527,
+                db_type="postgres",
+            )
+            self.store.initialise()
+        except OperationalError:
+            print("Database schema and data population failed! Test is skipping.")
+
+    def tearDown(self):
+        try:
+            self.postgres.stop()
+        except AttributeError:
+            return
+
+    def test_import_with_missing_db_field(self):
+        conn = pg8000.connect(user="postgres", password="postgres", database="test", port=55527)
+        cursor = conn.cursor()
+        # Alter table to drop heading column
+        cursor.execute('ALTER TABLE pepys."States" DROP COLUMN heading CASCADE;')
+
+        conn.commit()
+        conn.close()
+
+        temp_output = StringIO()
+        with redirect_stdout(temp_output):
+            db_config = {
+                "name": "test",
+                "host": "localhost",
+                "username": "postgres",
+                "password": "postgres",
+                "port": 55527,
+                "type": "postgres",
+            }
+
+            process(path=DATA_PATH, archive=False, db=db_config, resolver="default")
+        output = temp_output.getvalue()
+
+        assert "ERROR: SQL error when communicating with database" in output
+
+
+@pytest.mark.postgres
+class TestImportWithWrongTypeDBFieldPostgres(unittest.TestCase):
+    def setUp(self):
+        self.postgres = None
+        self.store = None
+        try:
+            self.postgres = Postgresql(
+                database="test", host="localhost", user="postgres", password="postgres", port=55527,
+            )
+        except RuntimeError:
+            print("PostgreSQL database couldn't be created! Test is skipping.")
+            return
+        try:
+            self.store = DataStore(
+                db_name="test",
+                db_host="localhost",
+                db_username="postgres",
+                db_password="postgres",
+                db_port=55527,
+                db_type="postgres",
+            )
+            self.store.initialise()
+        except OperationalError:
+            print("Database schema and data population failed! Test is skipping.")
+
+    def tearDown(self):
+        try:
+            self.postgres.stop()
+        except AttributeError:
+            return
+
+    def test_import_with_wrong_type_db_field(self):
+        conn = pg8000.connect(user="postgres", password="postgres", database="test", port=55527)
+        cursor = conn.cursor()
+        # Alter table to change heading column to be a timestamp
+        cursor.execute(
+            'ALTER TABLE pepys."States" ALTER COLUMN heading SET DATA TYPE character varying(150);'
+        )
+
+        conn.commit()
+        conn.close()
+
+        temp_output = StringIO()
+        with redirect_stdout(temp_output):
+            db_config = {
+                "name": "test",
+                "host": "localhost",
+                "username": "postgres",
+                "password": "postgres",
+                "port": 55527,
+                "type": "postgres",
+            }
+
+            process(path=DATA_PATH, archive=False, db=db_config, resolver="default")
+        output = temp_output.getvalue()
+
+        assert "ERROR: SQL error when communicating with database" in output


### PR DESCRIPTION
Adds exception handlers at a high level around both the pepys-import and pepys-admin CLIs, to catch a SQLAlchemy ProgrammingError, which occurs when the SQL doesn't make sense - eg. when fields are missing in the database.

Gives a sensible error message - but let me know if you want to reword it.