### PR TITLE
Added folder choice for exporting datafile

### DIFF
--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -9,6 +9,7 @@ from prompt_toolkit.completion.filesystem import PathCompleter
 
 from pepys_admin.export_by_platform_cli import ExportByPlatformNameShell
 from pepys_admin.initialise_cli import InitialiseShell
+from pepys_admin.utils import get_default_export_folder
 
 DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 
@@ -58,7 +59,7 @@ class AdminShell(cmd.Cmd):
             folder_completer = PathCompleter(only_directories=True, expanduser=True)
             folder_path = ptk_prompt(
                 "Please provide a folder path for the exported file: ",
-                default="~/",
+                default=get_default_export_folder(),
                 completer=folder_completer,
                 complete_while_typing=True,
             )

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -4,6 +4,8 @@ import sys
 from datetime import datetime
 
 from iterfzf import iterfzf
+from prompt_toolkit import prompt
+from prompt_toolkit.completion.filesystem import PathCompleter
 
 from pepys_admin.export_by_platform_cli import ExportByPlatformNameShell
 from pepys_admin.initialise_cli import InitialiseShell
@@ -53,13 +55,22 @@ class AdminShell(cmd.Cmd):
 
         export_flag = input(f"Do you want to export {selected_datafile}? (Y/n)\n")
         if export_flag in ["", "Y", "y"]:
+            folder_completer = PathCompleter(only_directories=True, expanduser=True)
+            folder_path = prompt(
+                "Please provide a folder path for the exported file: ",
+                default="~/",
+                completer=folder_completer,
+            )
+
             datafile_name = f"exported_{selected_datafile.replace('.', '_')}.rep"
             print(f"'{selected_datafile}' is going to be exported.")
-
             selected_datafile_id = datafiles_dict[selected_datafile]
+
+            export_file_full_path = os.path.expanduser(os.path.join(folder_path, datafile_name))
+
             with self.data_store.session_scope():
-                self.data_store.export_datafile(selected_datafile_id, datafile_name)
-            print(f"Datafile successfully exported to {datafile_name}.")
+                self.data_store.export_datafile(selected_datafile_id, export_file_full_path)
+            print(f"Datafile successfully exported to {export_file_full_path}.")
         elif export_flag in ["N", "n"]:
             print("You selected not to export!")
         else:

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -4,7 +4,7 @@ import sys
 from datetime import datetime
 
 from iterfzf import iterfzf
-from prompt_toolkit import prompt
+from prompt_toolkit import prompt as ptk_prompt
 from prompt_toolkit.completion.filesystem import PathCompleter
 
 from pepys_admin.export_by_platform_cli import ExportByPlatformNameShell
@@ -56,10 +56,11 @@ class AdminShell(cmd.Cmd):
         export_flag = input(f"Do you want to export {selected_datafile}? (Y/n)\n")
         if export_flag in ["", "Y", "y"]:
             folder_completer = PathCompleter(only_directories=True, expanduser=True)
-            folder_path = prompt(
+            folder_path = ptk_prompt(
                 "Please provide a folder path for the exported file: ",
                 default="~/",
                 completer=folder_completer,
+                complete_while_typing=True,
             )
 
             datafile_name = f"exported_{selected_datafile.replace('.', '_')}.rep"

--- a/pepys_admin/export_by_platform_cli.py
+++ b/pepys_admin/export_by_platform_cli.py
@@ -1,7 +1,7 @@
 import cmd
 import os
 
-from prompt_toolkit import prompt
+from prompt_toolkit import prompt as ptk_prompt
 from prompt_toolkit.completion.filesystem import PathCompleter
 
 
@@ -33,10 +33,11 @@ class ExportByPlatformNameShell(cmd.Cmd):
         export_file_name = file_name or default_export_name
 
         folder_completer = PathCompleter(only_directories=True, expanduser=True)
-        folder_path = prompt(
+        folder_path = ptk_prompt(
             "Please provide a folder path for the exported file: ",
             default="~/",
             completer=folder_completer,
+            complete_while_typing=True,
         )
 
         export_file_full_path = os.path.expanduser(os.path.join(folder_path, export_file_name))

--- a/pepys_admin/export_by_platform_cli.py
+++ b/pepys_admin/export_by_platform_cli.py
@@ -34,7 +34,7 @@ class ExportByPlatformNameShell(cmd.Cmd):
 
         folder_completer = PathCompleter(only_directories=True, expanduser=True)
         folder_path = prompt(
-            "Please provide a folder path for the exported file:",
+            "Please provide a folder path for the exported file: ",
             default="~/",
             completer=folder_completer,
         )

--- a/pepys_admin/export_by_platform_cli.py
+++ b/pepys_admin/export_by_platform_cli.py
@@ -4,6 +4,8 @@ import os
 from prompt_toolkit import prompt as ptk_prompt
 from prompt_toolkit.completion.filesystem import PathCompleter
 
+from pepys_admin.utils import get_default_export_folder
+
 
 class ExportByPlatformNameShell(cmd.Cmd):
     prompt = "(pepys-admin) (export by platform) "
@@ -35,7 +37,7 @@ class ExportByPlatformNameShell(cmd.Cmd):
         folder_completer = PathCompleter(only_directories=True, expanduser=True)
         folder_path = ptk_prompt(
             "Please provide a folder path for the exported file: ",
-            default="~/",
+            default=get_default_export_folder(),
             completer=folder_completer,
             complete_while_typing=True,
         )

--- a/pepys_admin/export_by_platform_cli.py
+++ b/pepys_admin/export_by_platform_cli.py
@@ -1,4 +1,8 @@
 import cmd
+import os
+
+from prompt_toolkit import prompt
+from prompt_toolkit.completion.filesystem import PathCompleter
 
 
 class ExportByPlatformNameShell(cmd.Cmd):
@@ -19,6 +23,7 @@ class ExportByPlatformNameShell(cmd.Cmd):
         sensor_id = option.get("sensor_id")  # May be missing if it's a Comment object
         platform_id = option.get("platform_id")  # May be missing if it's a State or Contact object
         default_export_name = f"exported_{option['name']}.rep"
+
         file_name = input(
             f"Please provide a name (Press Enter for default value " f"({default_export_name})):"
         )
@@ -26,10 +31,21 @@ class ExportByPlatformNameShell(cmd.Cmd):
             if not file_name.endswith(".rep"):
                 file_name += ".rep"
         export_file_name = file_name or default_export_name
-        print(f"Objects are going to be exported to '{export_file_name}'.")
+
+        folder_completer = PathCompleter(only_directories=True, expanduser=True)
+        folder_path = prompt(
+            "Please provide a folder path for the exported file:",
+            default="~/",
+            completer=folder_completer,
+        )
+
+        export_file_full_path = os.path.expanduser(os.path.join(folder_path, export_file_name))
+        print(f"Objects are going to be exported to '{export_file_full_path}'.")
         with self.data_store.session_scope():
-            self.data_store.export_datafile(datafile_id, export_file_name, sensor_id, platform_id)
-            print(f"Objects successfully exported to {export_file_name}.")
+            self.data_store.export_datafile(
+                datafile_id, export_file_full_path, sensor_id, platform_id
+            )
+            print(f"Objects successfully exported to {export_file_full_path}.")
         return True
 
     def default(self, line):

--- a/pepys_admin/utils.py
+++ b/pepys_admin/utils.py
@@ -1,0 +1,9 @@
+import os
+
+
+def get_default_export_folder():
+    current_folder_name = os.path.basename(os.path.normpath(os.getcwd()))
+    if current_folder_name == "bin":
+        return os.path.expanduser("~")
+    else:
+        return os.getcwd()

--- a/tests/test_admin_cli.py
+++ b/tests/test_admin_cli.py
@@ -34,13 +34,14 @@ class AdminCLITestCase(unittest.TestCase):
 
     @patch("pepys_admin.admin_cli.iterfzf", return_value="rep_test1.rep")
     @patch("pepys_admin.admin_cli.input", return_value="Y")
-    def test_do_export(self, patched_iterfzf, patched_input):
+    @patch("pepys_admin.admin_cli.ptk_prompt", return_value=".")
+    def test_do_export(self, patched_iterfzf, patched_input, patched_ptk_prompt):
         temp_output = StringIO()
         with redirect_stdout(temp_output):
             self.admin_shell.do_export()
         output = temp_output.getvalue()
         assert "'rep_test1.rep' is going to be exported." in output
-        assert "Datafile successfully exported to exported_rep_test1_rep.rep." in output
+        assert "Datafile successfully exported to ./exported_rep_test1_rep.rep." in output
 
         file_path = os.path.join(CURRENT_DIR, "exported_rep_test1_rep.rep")
         assert os.path.exists(file_path) is True
@@ -87,13 +88,16 @@ class AdminCLITestCase(unittest.TestCase):
     @patch("pepys_admin.admin_cli.iterfzf", return_value="SEARCH_PLATFORM")
     @patch("pepys_admin.export_by_platform_cli.input", return_value="")
     @patch("cmd.input", return_value="1")
-    def test_do_export_by_platform_name(self, cmd_input, shell_input, patched_iterfzf):
+    @patch("pepys_admin.export_by_platform_cli.ptk_prompt", return_value=".")
+    def test_do_export_by_platform_name(
+        self, cmd_input, shell_input, patched_iterfzf, patched_ptk_prompt
+    ):
         temp_output = StringIO()
         with redirect_stdout(temp_output):
             self.admin_shell.do_export_by_platform_name()
         output = temp_output.getvalue()
-        assert "Objects are going to be exported to 'exported_SEARCH_PLATFORM.rep'." in output
-        assert "Objects successfully exported to exported_SEARCH_PLATFORM.rep." in output
+        assert "Objects are going to be exported to './exported_SEARCH_PLATFORM.rep'." in output
+        assert "Objects successfully exported to ./exported_SEARCH_PLATFORM.rep." in output
 
         file_path = os.path.join(CURRENT_DIR, "exported_SEARCH_PLATFORM.rep")
         assert os.path.exists(file_path) is True
@@ -481,13 +485,14 @@ class ExportByPlatformNameShellTestCase(unittest.TestCase):
         self.shell.intro = self.text
 
     @patch("pepys_admin.export_by_platform_cli.input", return_value="export_test")
-    def test_do_export(self, patched_input):
+    @patch("pepys_admin.export_by_platform_cli.ptk_prompt", return_value=".")
+    def test_do_export(self, patched_input, patched_ptk_prompt):
         temp_output = StringIO()
         with redirect_stdout(temp_output):
             self.shell.do_export(self.objects[0])
         output = temp_output.getvalue()
-        assert "Objects are going to be exported to 'export_test.rep'." in output
-        assert "Objects successfully exported to export_test.rep." in output
+        assert "Objects are going to be exported to './export_test.rep'." in output
+        assert "Objects successfully exported to ./export_test.rep." in output
 
         file_path = os.path.join(CURRENT_DIR, "export_test.rep")
         assert os.path.exists(file_path) is True


### PR DESCRIPTION
Now asks the user which folder they want to export into. Uses prompt_toolkit which provides autocompletion for folder paths, starting with a default of ~ (user's home directory).

Tested and working on Windows and OS X.