### PR TITLE
Add previously-added date to message when skipping files during import 

### DIFF
--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -1416,7 +1416,9 @@ class DataStore:
             .first()
         )
         if is_loaded_before:
-            print(f"'{is_loaded_before.reference}' is already loaded! Skipping the file.")
+            print(
+                f"'{is_loaded_before.reference}' was already loaded at {is_loaded_before.created_date:%Y-%m-%d %H:%M}! Skipping the file."
+            )
             return True
         return False
 

--- a/tests/test_datafile.py
+++ b/tests/test_datafile.py
@@ -63,7 +63,7 @@ class DuplicatedFilesTestCase(unittest.TestCase):
         output = temp_output.getvalue()
 
         assert "Files got processed: 0 times" in output
-        assert "'rep_test1.rep' is already loaded! Skipping the file." in output
+        assert "'rep_test1.rep' was already loaded" in output
 
     def test_importing_the_same_file_with_different_name(self):
         """Test whether process method runs only once when the same datafile
@@ -82,7 +82,7 @@ class DuplicatedFilesTestCase(unittest.TestCase):
         output = temp_output.getvalue()
 
         assert "Files got processed: 0 times" in output
-        assert "'rep_test1.rep' is already loaded! Skipping the file." in output
+        assert "'rep_test1.rep' was already loaded" in output
         # Delete the copy file
         os.remove(copied_file_path)
 


### PR DESCRIPTION
Just adds the date the file was previously imported to the message. Output looks like

```
'sen_frig_sensor.dsf' was already loaded at 2020-04-09 15:23! Skipping the file.
```

Fixes #321.