### PR TITLE
Add CodeCov config file to tell it not to report coverage for the test files themselves

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "tests/**/*"  # ignore all tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "tests/**/*"  # ignore all tests
+  - "tests"  # ignore all tests


### PR DESCRIPTION
The reason for this is that one of the other PRs (#322) was reporting low coverage, but that was because
there were exceptions handled in the tests that weren't being triggered (they were for if Postgres
wasn't installed) - but this counted as low coverage. We don't need to record coverage of the test code itself
so we can just tell CodeCov to ignore this for its reports.