### PR TITLE
Speed up validators

### DIFF
--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -250,7 +250,7 @@ class DatafileMixin:
         elif validation_level == validation_constants.BASIC_LEVEL:
             # Create validator objects here so we're only creating them once
             bv = BasicValidator(parser)
-            local_bv_objects = [bv() for bv in LOCAL_BASIC_VALIDATORS]
+            local_bv_objects = [bv(parser) for bv in LOCAL_BASIC_VALIDATORS]
             print(f"Running basic validation for {parser}")
             for measurement in tqdm(self.measurements[parser]):
                 # Run the standard Basic Validator
@@ -267,7 +267,7 @@ class DatafileMixin:
             # Create validator objects here, so we're only creating them once
             bv = BasicValidator(parser)
             ev = EnhancedValidator()
-            local_bv_objects = [bv() for bv in LOCAL_BASIC_VALIDATORS]
+            local_bv_objects = [bv(parser) for bv in LOCAL_BASIC_VALIDATORS]
             local_ev_objects = [ev() for ev in LOCAL_ENHANCED_VALIDATORS]
             print(f"Running enhanced validation for {parser}")
             for objects in self.measurements[parser].values():

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -1,5 +1,6 @@
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.inspection import inspect
+from tqdm import tqdm
 
 from config import LOCAL_BASIC_TESTS, LOCAL_ENHANCED_TESTS
 from pepys_import.core.formats import unit_registry
@@ -247,38 +248,46 @@ class DatafileMixin:
         if validation_level == validation_constants.NONE_LEVEL:
             return (True, failed_validators)
         elif validation_level == validation_constants.BASIC_LEVEL:
-            for measurement in self.measurements[parser]:
-                bv = BasicValidator(parser)
+            # Create validator objects here so we're only creating them once
+            bv = BasicValidator(parser)
+            local_bv_objects = [bv() for bv in LOCAL_BASIC_VALIDATORS]
+            print(f"Running basic validation for {parser}")
+            for measurement in tqdm(self.measurements[parser]):
+                # Run the standard Basic Validator
                 if not bv.validate(measurement, errors):
                     failed_validators.append(bv.name)
-                for basic_validator in LOCAL_BASIC_VALIDATORS:
-                    bv = basic_validator(parser)
-                    if not bv.validate(measurement, errors):
+                # Run all the basic validators in the folder configured in the config file
+                for local_bv in local_bv_objects:
+                    if not local_bv.validate(measurement, errors):
                         failed_validators.append(bv.name)
             if not errors:
                 return (True, failed_validators)
             return (False, failed_validators)
         elif validation_level == validation_constants.ENHANCED_LEVEL:
+            # Create validator objects here, so we're only creating them once
+            bv = BasicValidator(parser)
+            ev = EnhancedValidator()
+            local_bv_objects = [bv() for bv in LOCAL_BASIC_VALIDATORS]
+            local_ev_objects = [ev() for ev in LOCAL_ENHANCED_VALIDATORS]
+            print(f"Running enhanced validation for {parser}")
             for objects in self.measurements[parser].values():
+                # Run the basic validators (standard one, plus configured local ones)
                 prev_object_dict = dict()
-                for curr_object in objects:
-                    bv = BasicValidator(parser)
+                for curr_object in tqdm(objects):
                     if not bv.validate(curr_object, errors):
                         failed_validators.append(bv.name)
-                    for basic_validator in LOCAL_BASIC_VALIDATORS:
-                        bv = basic_validator(parser)
-                        if not bv.validate(curr_object, errors):
+                    for local_bv in local_bv_objects:
+                        if not local_bv.validate(curr_object, errors):
                             failed_validators.append(bv.name)
-
                     prev_object = None
                     if curr_object.platform_name in prev_object_dict:
                         prev_object = prev_object_dict[curr_object.platform_name]
-                    ev = EnhancedValidator()
+
+                    # Run the enhanced validators (standard one, plus configured local ones)
                     if not ev.validate(curr_object, errors, parser, prev_object):
                         failed_validators.append(ev.name)
-                    for enhanced_validator in LOCAL_ENHANCED_VALIDATORS:
-                        ev = enhanced_validator()
-                        if not ev.validate(curr_object, errors, parser, prev_object):
+                    for local_ev in local_ev_objects:
+                        if not local_ev.validate(curr_object, errors, parser, prev_object):
                             failed_validators.append(ev.name)
                     prev_object_dict[curr_object.platform_name] = curr_object
 

--- a/pepys_import/core/validators/basic_validator.py
+++ b/pepys_import/core/validators/basic_validator.py
@@ -9,12 +9,22 @@ class BasicValidator:
         longitude = None
         latitude = None
 
-        heading = object_.heading if hasattr(object_, "heading") else None
-        course = object_.course if hasattr(object_, "course") else None
-        if hasattr(object_, "location"):
+        try:
+            heading = object_.heading
+        except AttributeError:
+            heading = None
+
+        try:
+            course = object_.course
+        except AttributeError:
+            course = None
+
+        try:
             if object_.location is not None:
                 longitude = object_.location.longitude
                 latitude = object_.location.latitude
+        except AttributeError:
+            pass
 
         self.validate_longitude(longitude, errors, self.error_type)
         self.validate_latitude(latitude, errors, self.error_type)

--- a/pepys_import/core/validators/enhanced_validator.py
+++ b/pepys_import/core/validators/enhanced_validator.py
@@ -40,10 +40,9 @@ class EnhancedValidator:
         except AttributeError:
             location = None
 
-        try:
-            time = current_object.time
-        except AttributeError:
-            time = None
+        # Doesn't need a try-catch as time is a compulsory field, created
+        # when a state is initialised
+        time = current_object.time
 
         if prev_object:
             try:
@@ -51,10 +50,9 @@ class EnhancedValidator:
             except AttributeError:
                 prev_location = None
 
-            try:
-                prev_time = prev_object.time
-            except AttributeError:
-                prev_time = None
+            # Doesn't need a try-catch as time is a compulsory field, created
+            # when a state is initialised
+            prev_time = prev_object.time
 
             if location and prev_location:
                 self.course_heading_loose_match_with_location(

--- a/pepys_import/core/validators/enhanced_validator.py
+++ b/pepys_import/core/validators/enhanced_validator.py
@@ -20,15 +20,41 @@ class EnhancedValidator:
             f"{str(current_object.time)}, Sensor:"
             f"{current_object.sensor_name}, Platform:{current_object.platform_name}"
         )
-        heading = current_object.heading if hasattr(current_object, "heading") else None
-        course = current_object.course if hasattr(current_object, "course") else None
-        speed = current_object.speed if hasattr(current_object, "speed") else None
-        location = current_object.location if hasattr(current_object, "location") else None
-        time = current_object.time if hasattr(current_object, "time") else None
+        try:
+            heading = current_object.heading
+        except AttributeError:
+            heading = None
+
+        try:
+            course = current_object.course
+        except AttributeError:
+            course = None
+
+        try:
+            speed = current_object.speed
+        except AttributeError:
+            speed = None
+
+        try:
+            location = current_object.location
+        except AttributeError:
+            location = None
+
+        try:
+            time = current_object.time
+        except AttributeError:
+            time = None
 
         if prev_object:
-            prev_location = prev_object.location if hasattr(prev_object, "location") else None
-            prev_time = prev_object.time if hasattr(prev_object, "time") else None
+            try:
+                prev_location = prev_object.location
+            except AttributeError:
+                prev_location = None
+
+            try:
+                prev_time = prev_object.time
+            except AttributeError:
+                prev_time = None
 
             if location and prev_location:
                 self.course_heading_loose_match_with_location(


### PR DESCRIPTION
This PR speeds up the running of the Basic and Enhanced validators by changing two things:

1. We now instantiate the validator classes _outside_ of the loop - we used to instantiate a new validator each time! This is only possible because I changed the validators to work on a `validate` method rather than in the `__init__` function in a PR a couple of weeks ago. I didn't think at the time that I could move the instantiation.

2. We do a fairly minor change that seems to have a significant speedup. In the validators we have a lot of code that looks like this:

```
heading = object_.heading if hasattr(object_, "heading") else None
```

If we replace it with:

```
try:
    heading = object_.heading
except AttributeError:
    heading = None
```
then it is a lot faster. Presumably this is because it isn't hitting the `except` clause much (because most states have a heading value) - but anyway, the two chunks of code are equivalent, so we might as well use the faster one even though it's slightly more verbose.