### PR TITLE
Hotfix - Can't find property named "ambig_bearing" on mapped class Contact->Contacts in this Query

### DIFF
--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -557,9 +557,9 @@ class ContactMixin:
         # Set the actual bearing attribute to the given value converted to radians
         self._ambig_bearing = ambig_bearing.to(unit_registry.radian).magnitude
 
-    @rel_bearing.expression
-    def rel_bearing(self):
-        return self._rel_bearing
+    @ambig_bearing.expression
+    def ambig_bearing(self):
+        return self._ambig_bearing
 
     #
     # MLA properties


### PR DESCRIPTION
Querying `ambig_bearing` was causing AttributeError. This PR fixes this error.