### PR TITLE
Split README in docs, and added Binder link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,18 +11,23 @@ PostgreSQL and SQLite databases are currently supported, with SQLite being
 the low-friction option favoured for getting started with Pepys-import, or
 for project maintainers.
 
-**Note:** This README file is aimed at *users* of pepys-import - please see the `Developer Guide
-<https://github.com/debrief/pepys-import/blob/develop/DeveloperGuide.rst>`_ for information on
-getting started as a developer.
+To try out Pepys without installing anything, click this button to run the *Getting Started*
+guide in an interactive notebook on the Binder platform: |binder|
+
+.. |binder| image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/debrief/pepys-import/develop?filepath=docs%2FPepys%20Getting%20Started%20-%20Binder.ipynb
 
 Online documentation
 --------------------
 
-Use the links on the left to learn about how to install and run Pepys-Import.
-
-More details on the structure and API of pepys-import is available in the full documentation: |docs|
+Full documentation for Pepys is available here: |docs|
 
 .. |docs| image:: https://readthedocs.org/projects/pepys-import/badge/?version=latest
   :target:  modules.html
 
+Development documentation
+-------------------------
 
+The developer setup guide is available `here
+<https://pepys-import.readthedocs.io/en/latest/developer_guide.html>`_, and the contributors guide
+is available `here <https://pepys-import.readthedocs.io/en/latest/contributing.html>`_.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,1 +1,0 @@
-.. include:: ../README.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,11 +6,32 @@
 Welcome to pepys-import
 =======================
 
+Introduction
+============
+
+Pepys-import is a Python library to be used in the parsing and
+collation of data to be used in platform-based spatial analysis.
+
+The library provides tools to help work through text data-files, and then
+push data measurements (and supporting metadata) to a databases.
+
+PostgreSQL and SQLite databases are currently supported, with SQLite being
+the low-friction option favoured for getting started with Pepys-import, or
+for project maintainers.
+
+To try out Pepys without installing anything, click this button to run the *Getting Started*
+guide in an interactive notebook on the Binder platform: |binder|
+
+.. |binder| image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/debrief/pepys-import/develop?filepath=docs%2FPepys%20Getting%20Started%20-%20Binder.ipynb
+
+For further information, use the links on the left or the full Table of Contents below to read the
+full Pepys documentation.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-   README.rst
    installation
    getting_started
    usage


### PR DESCRIPTION
This PR splits the README file in the root of the repo from the docs homepage, so we can have different content in each. It also adds a Binder link to both the README and the docs homepage.

Fixes #358 