### PR TITLE
Add multi-column unique constraints

### DIFF
--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -7,6 +7,7 @@ from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP, UUID
 from sqlalchemy.orm import (  # used to defer fetching attributes unless it's specifically called
     deferred,
 )
+from sqlalchemy.sql.schema import UniqueConstraint
 
 from pepys_import.core.store import constants
 from pepys_import.core.store.common_db import (
@@ -56,7 +57,10 @@ class Sensor(BasePostGIS, SensorMixin):
     __tablename__ = constants.SENSOR
     table_type = TableTypes.METADATA
     table_type_id = 2
-    __table_args__ = {"schema": "pepys"}
+    __table_args__ = (
+        UniqueConstraint("name", "host", name="uq_sensors_name_host"),
+        {"schema": "pepys"},
+    )
 
     sensor_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     name = Column(String(150), nullable=False)
@@ -140,7 +144,10 @@ class Datafile(BasePostGIS, DatafileMixin):
     __tablename__ = constants.DATAFILE
     table_type = TableTypes.METADATA
     table_type_id = 6  # Only needed for tables referenced by Entry table
-    __table_args__ = {"schema": "pepys"}
+    __table_args__ = (
+        UniqueConstraint("size", "hash", name="uq_Datafile_size_hash"),
+        {"schema": "pepys"},
+    )
 
     datafile_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     simulated = deferred(Column(Boolean, nullable=False))
@@ -275,7 +282,10 @@ class GeometrySubType(BasePostGIS):
     __tablename__ = constants.GEOMETRY_SUBTYPE
     table_type = TableTypes.REFERENCE
     table_type_id = 16
-    __table_args__ = {"schema": "pepys"}
+    __table_args__ = (
+        UniqueConstraint("name", "parent", name="uq_GeometrySubType_name_parent"),
+        {"schema": "pepys"},
+    )
 
     geo_sub_type_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     name = Column(String(150), nullable=False, unique=True)

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -6,6 +6,7 @@ from sqlalchemy.dialects.sqlite import REAL, TIMESTAMP
 from sqlalchemy.orm import (  # used to defer fetching attributes unless it's specifically called
     deferred,
 )
+from sqlalchemy.sql.schema import UniqueConstraint
 
 from pepys_import.core.store import constants
 from pepys_import.core.store.common_db import (
@@ -57,6 +58,8 @@ class Sensor(BaseSpatiaLite, SensorMixin):
     host = Column(Integer, ForeignKey("Platforms.platform_id"), nullable=False)
     privacy_id = Column(Integer, ForeignKey("Privacies.privacy_id"), nullable=False)
     created_date = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = UniqueConstraint("name", "host", name="uq_sensors_name_host")
 
 
 class Platform(BaseSpatiaLite, PlatformMixin):
@@ -124,6 +127,8 @@ class Datafile(BaseSpatiaLite, DatafileMixin):
     size = deferred(Column(Integer, nullable=False))
     hash = deferred(Column(String(32), nullable=False))
     created_date = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = UniqueConstraint("size", "hash", name="uq_Datafile_size_hash")
 
 
 class Synonym(BaseSpatiaLite):
@@ -237,9 +242,11 @@ class GeometrySubType(BaseSpatiaLite):
     table_type_id = 16
 
     geo_sub_type_id = Column(Integer, primary_key=True)
-    name = Column(String(150), nullable=False, unique=True)
+    name = Column(String(150), nullable=False)
     parent = Column(Integer, nullable=False)
     created_date = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = UniqueConstraint("name", "parent", name="uq_GeometrySubType_name_parent")
 
 
 class User(BaseSpatiaLite):


### PR DESCRIPTION
WIP

According to #379, various tables have multi-column unique constraints - for example, the Sensor table must be unique on the combination of `name` and `host`.

This PR enforces those constraints in the database.

Still todo:
- [ ] Add more constraints once #379 is fully sorted
- [ ] Add migrations
- [ ] Add tests