### PR TITLE
Give More Info on Selections in Pepys-Admin

### DIFF
--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -270,7 +270,7 @@ class AdminShell(cmd.Cmd):
             ).all()
             privacy_dict = {name: privacy_id for privacy_id, name in privacies}
         message = (
-            "Export all data with the selected classification(s). " "(Press TAB) for multi-select >"
+            "Export all data with the selected classification(s). (Press TAB) for multi-select >"
         )
         selected_privacies = iterfzf(privacy_dict.keys(), multi=True, prompt=message)
         if selected_privacies is None:

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -267,6 +267,9 @@ class AdminShell(cmd.Cmd):
             ).all()
             privacy_dict = {name: privacy_id for privacy_id, name in privacies}
         selected_privacies = iterfzf(privacy_dict.keys(), multi=True)
+        if selected_privacies is None:
+            print("Returning to the previous menu")
+            return
         privacy_ids = [privacy_dict[name] for name in selected_privacies]
         export_metadata_tables(self.data_store, destination_store, privacy_ids)
         print(

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -270,7 +270,7 @@ class AdminShell(cmd.Cmd):
             ).all()
             privacy_dict = {name: privacy_id for privacy_id, name in privacies}
         message = (
-            "Export all data with the selected classification(s). (Press TAB) for multi-select >"
+            "Export all data with the selected classification(s). (Press TAB for multi-select) >"
         )
         selected_privacies = iterfzf(privacy_dict.keys(), multi=True, prompt=message)
         if selected_privacies is None:

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -70,7 +70,8 @@ class AdminShell(cmd.Cmd):
                 print("There is no datafile found in the database!")
                 return
             datafiles_dict = {d.reference: d.datafile_id for d in datafiles}
-        selected_datafile = iterfzf(datafiles_dict.keys())
+        message = "Select a datafile to export > "
+        selected_datafile = iterfzf(datafiles_dict.keys(), prompt=message)
 
         if selected_datafile is None or selected_datafile not in datafiles_dict.keys():
             print(f"You haven't selected a valid option!")
@@ -111,7 +112,8 @@ class AdminShell(cmd.Cmd):
                 print("There is no platform found in the database!")
                 return
             platforms_dict = {p.name: p.platform_id for p in platforms}
-        selected_platform = iterfzf(platforms_dict.keys())
+        message = "Select a platform name to export datafiles that include it > "
+        selected_platform = iterfzf(platforms_dict.keys(), prompt=message)
 
         if selected_platform is None or selected_platform not in platforms_dict.keys():
             print(f"You haven't selected a valid option!")
@@ -124,7 +126,8 @@ class AdminShell(cmd.Cmd):
         with self.data_store.session_scope():
             objects = self.data_store.find_related_datafile_objects(platform_id, sensors_dict)
         # Create a dynamic menu for the found datafile objects
-        text = "--- Menu ---\n"
+        text = "Select from the found datafile objects.\n"
+        text += "--- Menu ---\n"
         options = [
             "0",
         ]
@@ -266,7 +269,9 @@ class AdminShell(cmd.Cmd):
                 self.data_store.db_classes.Privacy.name,
             ).all()
             privacy_dict = {name: privacy_id for privacy_id, name in privacies}
-        message = "Select classification level(s) to export. (Press TAB) for multi-select >"
+        message = (
+            "Export all data with the selected classification(s). " "(Press TAB) for multi-select >"
+        )
         selected_privacies = iterfzf(privacy_dict.keys(), multi=True, prompt=message)
         if selected_privacies is None:
             print("Returning to the previous menu")

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -266,7 +266,8 @@ class AdminShell(cmd.Cmd):
                 self.data_store.db_classes.Privacy.name,
             ).all()
             privacy_dict = {name: privacy_id for privacy_id, name in privacies}
-        selected_privacies = iterfzf(privacy_dict.keys(), multi=True)
+        message = "Select classification level(s) to export. (Press TAB) for multi-select >"
+        selected_privacies = iterfzf(privacy_dict.keys(), multi=True, prompt=message)
         if selected_privacies is None:
             print("Returning to the previous menu")
             return

--- a/pepys_admin/view_data_cli.py
+++ b/pepys_admin/view_data_cli.py
@@ -57,7 +57,8 @@ class ViewDataShell(cmd.Cmd):
                 and not name.startswith("sql")
                 and not name.lower().startswith("spatial")
             ]
-        selected_table = iterfzf(table_names)
+        message = "Select a table >"
+        selected_table = iterfzf(table_names, prompt=message)
         if selected_table is None:
             return
         # Table names are plural in the database, therefore make it singular

--- a/tests/test_admin_cli.py
+++ b/tests/test_admin_cli.py
@@ -1002,6 +1002,19 @@ class ExportMetadataTestCase(unittest.TestCase):
         if os.path.exists(path):
             os.remove(path)
 
+    @patch("pepys_admin.admin_cli.input", return_value="test.db")
+    @patch("pepys_admin.admin_cli.iterfzf", return_value=None)
+    def test_do_export_reference_and_metadata_cancelling(self, patched_iterfzf, patched_input):
+        temp_output = StringIO()
+        with redirect_stdout(temp_output):
+            self.admin_shell.do_export_reference_and_metadata_data()
+        output = temp_output.getvalue()
+        assert "Returning to the previous menu" in output
+
+        path = os.path.join(os.getcwd(), "test.db")
+        if os.path.exists(path):
+            os.remove(path)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #410 .

Note: I realised that when selecting Privacy is canceled during the export reference and metadata, the Pepys Admin was failing. This PR has a fix for this issue as well.