### PR TITLE
Hotfix - Don't allow duplicate entries to be added for Sensor, Platform, Datafile, Synonym

### DIFF
--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -280,6 +280,22 @@ class DataStore:
         elif privacy is None:
             raise MissingDataException("Privacy is missing/invalid")
 
+        # Check if entry already exists with these details, and if so, just return it
+        # Just check the unique fields - in this case: name and host
+        # TODO: Possibly update when we get final uniqueness info from client
+        results = (
+            self.session.query(self.db_classes.Sensor)
+            .filter(self.db_classes.Sensor.name == name)
+            .filter(self.db_classes.Sensor.host == host.platform_id)
+            .all()
+        )
+
+        if len(results) == 1:
+            # Don't add it, as it already exists - just return it
+            return results[0]
+        elif len(results) > 1:
+            assert False, "Fatal error: Duplicate entries found in Sensors table"
+
         sensor_obj = self.db_classes.Sensor(
             name=name,
             sensor_type_id=sensor_type.sensor_type_id,
@@ -332,6 +348,22 @@ class DataStore:
             raise MissingDataException("Datafile Type is invalid/missing")
         elif privacy is None:
             raise MissingDataException("Privacy is invalid/missing")
+
+        # Check if entry already exists with these details, and if so, just return it
+        # Just check the unique fields - in this case: size and hash
+        # TODO: Possibly update when we get final uniqueness info from client
+        results = (
+            self.session.query(self.db_classes.Datafile)
+            .filter(self.db_classes.Datafile.size == file_size)
+            .filter(self.db_classes.Datafile.hash == file_hash)
+            .all()
+        )
+
+        if len(results) == 1:
+            # Don't add it, as it already exists - just return it
+            return results[0]
+        elif len(results) > 1:
+            assert False, "Fatal error: Duplicate entries found in Datafiles table"
 
         datafile_obj = self.db_classes.Datafile(
             simulated=bool(simulated),
@@ -395,6 +427,23 @@ class DataStore:
         elif privacy is None:
             raise MissingDataException("Privacy is invalid/missing")
 
+        # Check if entry already exists with these details, and if so, just return it
+        # Just check the unique fields - in this case: name, nationality_id and identifier
+        # TODO: Possibly update when we get final uniqueness info from client
+        results = (
+            self.session.query(self.db_classes.Platform)
+            .filter(self.db_classes.Platform.name == name)
+            .filter(self.db_classes.Platform.nationality_id == nationality.nationality_id)
+            .filter(self.db_classes.Platform.identifier == identifier)
+            .all()
+        )
+
+        if len(results) == 1:
+            # Don't add it, as it already exists - just return it
+            return results[0]
+        elif len(results) > 1:
+            assert False, "Fatal error: Duplicate entries found in Platforms table"
+
         platform_obj = self.db_classes.Platform(
             name=name,
             trigraph=trigraph,
@@ -417,6 +466,22 @@ class DataStore:
         # Blacklist certain tables, and don't Synonyms for them be created
         if table in [constants.SENSOR, constants.GEOMETRY_SUBTYPE]:
             raise Exception(f"Synonyms are not allowed for table {table}")
+
+        # Check if entry already exists with these details, and if so, just return it
+        # Just check the unique fields - in this case: name and table
+        # TODO: Possibly update when we get final uniqueness info from client
+        results = (
+            self.session.query(self.db_classes.Synonym)
+            .filter(self.db_classes.Synonym.synonym == name)
+            .filter(self.db_classes.Synonym.table == table)
+            .all()
+        )
+
+        if len(results) == 1:
+            # Don't add it, as it already exists - just return it
+            return results[0]
+        elif len(results) > 1:
+            assert False, "Fatal error: Duplicate entries found in Synonyms table"
 
         # enough info to proceed and create entry
         synonym = self.db_classes.Synonym(table=table, synonym=name, entity=entity)

--- a/tests/test_data_store_populate.py
+++ b/tests/test_data_store_populate.py
@@ -352,5 +352,44 @@ class DataStorePopulateMissingData(TestCase):
             assert "  Error was 'Host is missing/invalid'" in output
 
 
+class DataStorePopulateTwice(TestCase):
+    def setUp(self):
+        self.store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+        self.store.initialise()
+
+    def tearDown(self):
+        pass
+
+    def test_populate_twice(self):
+        with self.store.session_scope():
+            self.store.populate_reference(TEST_DATA_PATH)
+            self.store.populate_metadata(TEST_DATA_PATH)
+
+        with self.store.session_scope():
+            # Check number of entries in a couple of tables
+            platforms = self.store.session.query(self.store.db_classes.Platform).all()
+
+            assert len(platforms) == 2
+
+            sensor_types = self.store.session.query(self.store.db_classes.SensorType).all()
+
+            assert len(sensor_types) == 3
+
+        # Load again
+        with self.store.session_scope():
+            self.store.populate_reference(TEST_DATA_PATH)
+            self.store.populate_metadata(TEST_DATA_PATH)
+
+        # Check number of entries is the same
+        with self.store.session_scope():
+            platforms = self.store.session.query(self.store.db_classes.Platform).all()
+
+            assert len(platforms) == 2
+
+            sensor_types = self.store.session.query(self.store.db_classes.SensorType).all()
+
+            assert len(sensor_types) == 3
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,0 +1,143 @@
+from datetime import datetime
+
+from pepys_import.core.store.data_store import DataStore
+
+
+def test_adding_duplicate_platform():
+    store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+    store.initialise()
+
+    with store.session_scope():
+        store.populate_reference()
+        change_id = store.add_to_changes("TEST", datetime.utcnow(), "TEST").change_id
+
+        store.add_to_platforms(
+            "TestPlatform",
+            "TestIdentifier",
+            "United Kingdom",
+            "PLATFORM-TYPE-1",
+            "Public",
+            change_id=change_id,
+        )
+
+        results = store.session.query(store.db_classes.Platform).all()
+
+        # Should be one Platform now
+        assert len(results) == 1
+
+    with store.session_scope():
+        # Add platform with same details again
+        store.add_to_platforms(
+            "TestPlatform",
+            "TestIdentifier",
+            "United Kingdom",
+            "PLATFORM-TYPE-1",
+            "Public",
+            change_id=change_id,
+        )
+
+        results = store.session.query(store.db_classes.Platform).all()
+
+        # Should still be one Platform
+        assert len(results) == 1
+
+
+def test_adding_duplicate_sensor():
+    store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+    store.initialise()
+
+    with store.session_scope():
+        store.populate_reference()
+        change_id = store.add_to_changes("TEST", datetime.utcnow(), "TEST").change_id
+
+        # Add Platform for this Sensor to belong to
+        store.add_to_platforms(
+            "TestPlatform",
+            "TestIdentifier",
+            "United Kingdom",
+            "PLATFORM-TYPE-1",
+            "Public",
+            change_id=change_id,
+        )
+
+        store.add_to_sensors("TestSensor", "GPS", "TestPlatform", "Public", change_id=change_id)
+
+        results = store.session.query(store.db_classes.Sensor).all()
+
+        # Should be one Sensor now
+        assert len(results) == 1
+
+    with store.session_scope():
+        # Add Sensor with same details again
+        store.add_to_sensors("TestSensor", "GPS", "TestPlatform", "Public", change_id=change_id)
+
+        results = store.session.query(store.db_classes.Sensor).all()
+
+        # Should still be one Sensor
+        assert len(results) == 1
+
+
+def test_adding_duplicate_datafile():
+    store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+    store.initialise()
+
+    with store.session_scope():
+        store.populate_reference()
+        change_id = store.add_to_changes("TEST", datetime.utcnow(), "TEST").change_id
+
+        store.add_to_datafiles(
+            "Public", "DATAFILE-TYPE-1", file_size=500, file_hash="TestHash", change_id=change_id
+        )
+
+        results = store.session.query(store.db_classes.Datafile).all()
+
+        # Should be one Datafile now
+        assert len(results) == 1
+
+    with store.session_scope():
+        # Add Datafile with same details again
+        store.add_to_datafiles(
+            "Public", "DATAFILE-TYPE-1", file_size=500, file_hash="TestHash", change_id=change_id
+        )
+
+        results = store.session.query(store.db_classes.Datafile).all()
+
+        # Should still be one Datafile
+        assert len(results) == 1
+
+
+def test_adding_duplicate_synonym():
+    store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+    store.initialise()
+
+    with store.session_scope():
+        store.populate_reference()
+        change_id = store.add_to_changes("TEST", datetime.utcnow(), "TEST").change_id
+
+        # Add Platform for the Synonym to point to
+        platform = store.add_to_platforms(
+            "TestPlatform",
+            "TestIdentifier",
+            "United Kingdom",
+            "PLATFORM-TYPE-1",
+            "Public",
+            change_id=change_id,
+        )
+
+        platform_id = platform.platform_id
+
+        store.add_to_synonyms("Platforms", "TestSynonym", platform_id, change_id=change_id)
+
+        results = store.session.query(store.db_classes.Synonym).all()
+
+        # Should be one Synonym now
+        assert len(results) == 1
+
+    with store.session_scope():
+        # Add Synonym again
+        store.add_to_synonyms("Platforms", "TestSynonym", platform_id, change_id=change_id)
+
+        results = store.session.query(store.db_classes.Synonym).all()
+
+        # Should still be one Synonym
+        assert len(results) == 1


### PR DESCRIPTION
This PR stops duplicate entries being added for Sensor, Platform, Datafile and Synonym. This is particularly useful when importing from CSV files (see #394).

I was _sure_ this had already been implemented, but tests today for something else revealed that it was only implemented for the reference tables but _not_ for the metadata tables.

This implements this for the metadata tables - it just returns the existing entry rather than adding an entry if an entry already exists with the same details.