### PR TITLE
Try to connect to the database at the beginning

### DIFF
--- a/pepys_import/utils/error_handling.py
+++ b/pepys_import/utils/error_handling.py
@@ -57,6 +57,7 @@ def handle_first_connection_error(connection_string):
         sqlalchemy.exc.ProgrammingError,
         sqlalchemy.exc.OperationalError,
         sqlalchemy.exc.InvalidRequestError,
+        sqlalchemy.exc.DatabaseError,
     ) as e:
         print(
             f"SQL Exception details: {e}\n\n"

--- a/pepys_import/utils/error_handling.py
+++ b/pepys_import/utils/error_handling.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import contextmanager
 
 import sqlalchemy
@@ -46,3 +47,22 @@ def handle_status_errors():
             "Please check your database structure is up-to-date with that expected "
             "by the version of Pepys you have installed.\n"
         )
+
+
+@contextmanager
+def handle_first_connection_error(connection_string):
+    try:
+        yield
+    except (
+        sqlalchemy.exc.ProgrammingError,
+        sqlalchemy.exc.OperationalError,
+        sqlalchemy.exc.InvalidRequestError,
+    ) as e:
+        print(
+            f"SQL Exception details: {e}\n\n"
+            "ERROR: SQL error when communicating with database\n"
+            f"Please check your database file and the config file's database section.\n"
+            f"Current database URL: '{connection_string}'\n"
+            "See above for the full error from SQLAlchemy."
+        )
+        sys.exit(1)

--- a/tests/test_data_store_api_spatialite.py
+++ b/tests/test_data_store_api_spatialite.py
@@ -779,6 +779,7 @@ class FirstConnectionTestCase(TestCase):
         assert "ERROR: SQL error when communicating with database" in output
         assert "Please check your database file and the config file's database section." in output
         assert "Current database URL: 'sqlite+pysqlite://:@:0/" in output
+        assert "__init__.py" in output
 
 
 if __name__ == "__main__":

--- a/tests/test_data_store_api_spatialite.py
+++ b/tests/test_data_store_api_spatialite.py
@@ -1,6 +1,8 @@
 import os
 import unittest
+from contextlib import redirect_stdout
 from datetime import datetime
+from io import StringIO
 from unittest import TestCase
 
 import pytest
@@ -758,6 +760,27 @@ class SynonymsTestCase(TestCase):
 
         with pytest.raises(Exception):
             self.store.add_to_synonyms("GeometrySubTypes", "TestName", "TestEntity", "TestChangeID")
+
+
+class FirstConnectionTestCase(TestCase):
+    def test_data_store_fails_at_the_beginning(self):
+        temp_output = StringIO()
+        with pytest.raises(SystemExit), redirect_stdout(temp_output):
+            DataStore(
+                db_host="",
+                db_username="",
+                db_password="",
+                db_port=0,
+                db_name="test_data_store_api_spatialite.py",  # Give a file that is not a database
+                db_type="sqlite",
+            )
+        output = temp_output.getvalue()
+        assert "ERROR: SQL error when communicating with database" in output
+        assert "Please check your database file and the config file's database section." in output
+        assert (
+            "Current database URL: 'sqlite+pysqlite://:@:0/test_data_store_api_spatialite.py'"
+            in output
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_data_store_api_spatialite.py
+++ b/tests/test_data_store_api_spatialite.py
@@ -765,22 +765,20 @@ class SynonymsTestCase(TestCase):
 class FirstConnectionTestCase(TestCase):
     def test_data_store_fails_at_the_beginning(self):
         temp_output = StringIO()
+        db_name = os.path.join(FILE_PATH, "__init__.py")
         with pytest.raises(SystemExit), redirect_stdout(temp_output):
             DataStore(
                 db_host="",
                 db_username="",
                 db_password="",
                 db_port=0,
-                db_name="test_data_store_api_spatialite.py",  # Give a file that is not a database
+                db_name=db_name,  # Give a file that is not a database
                 db_type="sqlite",
             )
         output = temp_output.getvalue()
         assert "ERROR: SQL error when communicating with database" in output
         assert "Please check your database file and the config file's database section." in output
-        assert (
-            "Current database URL: 'sqlite+pysqlite://:@:0/test_data_store_api_spatialite.py'"
-            in output
-        )
+        assert "Current database URL: 'sqlite+pysqlite://:@:0/" in output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When a DataStore object is created, it creates a connection string and an engine that is going to connect to the created string. However, it works lazily and it doesn't try to connect to the database URL if `engine.connect()` is not called. However, when the welcome text and the status are printed, it seems like DataStore is connected to the given database, which is misleading. This PR solves this problem.