### PR TITLE
Add extraction of platform name from track name in GPX importer

### DIFF
--- a/importers/gpx_importer.py
+++ b/importers/gpx_importer.py
@@ -49,9 +49,11 @@ class GPXImporter(Importer):
         # Iterate through <trk> elements - these should correspond to
         # a specific platform, with the platform name in the <name> element
         for track_element in tqdm(doc.findall("//{*}trk")):
+            track_name = track_element.find("{*}name").text
+
             # Get the platform and sensor details, as these will be the same for all
             # points in this track
-            platform = data_store.get_platform(platform_name=None, change_id=change_id,)
+            platform = data_store.get_platform(platform_name=track_name, change_id=change_id,)
             sensor_type = data_store.add_to_sensor_types("GPS", change_id=change_id).name
             sensor = platform.get_sensor(
                 data_store=data_store,

--- a/tests/test_load_gpx.py
+++ b/tests/test_load_gpx.py
@@ -44,12 +44,9 @@ class GPXTests(unittest.TestCase):
             states = self.store.session.query(self.store.db_classes.State).all()
             assert len(states) == 27
 
-            # there must be a platform after import
-            # (Note: as the platform name is no longer imported from the track name,
-            # all files will have the same platform name - the default one generated
-            # by the default resolver)
+            # there must be 3 platforms after import
             platforms = self.store.session.query(self.store.db_classes.Platform).all()
-            assert len(platforms) == 1
+            assert len(platforms) == 3
 
             # there must be one datafile afterwards
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
@@ -58,6 +55,8 @@ class GPXTests(unittest.TestCase):
             #
             # Test the actual values that are imported
             #
+            platform_names = [platform.name for platform in platforms]
+            assert "NELSON" in platform_names
 
             # there should be 3 States with a speed of 4.5m/s
             # as the first <trkpt> element in gpx_1_0.gpx has been imported

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -2193,7 +2193,7 @@ class TestExportAlterAndMerge(unittest.TestCase):
 
                 platform_names = [p.name for p in platform_results]
 
-                assert len(platform_names) == 8
+                assert len(platform_names) == 9
 
                 assert "Master_Platform_1" in platform_names
                 assert "Slave_Platform_1" in platform_names
@@ -2455,7 +2455,7 @@ class TestExportAlterAndMerge_Postgres(unittest.TestCase):
 
                 platform_names = [p.name for p in platform_results]
 
-                assert len(platform_names) == 8
+                assert len(platform_names) == 9
 
                 assert "Master_Platform_1" in platform_names
                 assert "Slave_Platform_1" in platform_names


### PR DESCRIPTION
This adds extraction of the platform name from GPX files, if the platform name is given as the track name in the file. Tests updated too.

Fixes #390.