### PR TITLE
Turn off enforcement of foreign key constraints before running migrations

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -174,6 +174,8 @@ def run_migrations_online():
                 context.execute("SET search_path TO pepys,public")
                 context.run_migrations()
         else:
+            # Turn off the enforcement of foreign key constraints before running the migration
+            connection.execute("PRAGMA foreign_keys=OFF;")
             context.configure(
                 connection=connection,
                 target_metadata=target_metadata,
@@ -184,6 +186,8 @@ def run_migrations_online():
             )
             with context.begin_transaction():
                 context.run_migrations()
+            # Turn on the enforcement of foreign key constraints after the migration is done
+            connection.execute("PRAGMA foreign_keys=ON;")
 
 
 if context.is_offline_mode():


### PR DESCRIPTION
As it's discussed in #476, migration failed for SQLite because of a foreign key constraint error. I said we already turned off the enforcement of foreign key constraints but I realised that it's only _partially_ true. Because in `migrations/env.py`'s `run_migrations_online` function, we allowed using already created database connections instead of opening a new one. And Pepys-Admin's `migrate` option uses an existing connection that has foreign key enforcement turned on. So, I added turn off and turn on commands no matter what kind of connection is passed to the `run_migrations_online` function. After that, `migrate` command started working correctly.


Note: In the issue, there was a discussion about the merge. This PR doesn't do anything related to that.