### PR TITLE
Create file associations for .sqlite and .db files with Pepys Admin

### DIFF
--- a/bin/install_pepys.ps1
+++ b/bin/install_pepys.ps1
@@ -83,4 +83,19 @@ if (!($env:Path -split ';' -contains $pepys_bin_path)) {
         [EnvironmentVariableTarget]::User)
 }
 
+# Create file associations for .sqlite and .db files to open in Pepys Admin
+$pepys_admin_run_command = [System.IO.Path]::GetFullPath(".\pepys_admin.bat") + " --db %1"
 
+# All of the assigning to $null below is just to stop the default output showing exactly
+# what registry keys have been created
+
+# Create the file extension entry for .sqlite and assign it to the filetype sqlitefile
+$null = New-Item -Path HKCU:\Software\Classes -Name .sqlite -Value sqlitefile -Force
+# Do the same for the .db extension
+$null = New-Item -Path HKCU:\Software\Classes -Name .db -Value sqlitefile -Force
+# Specify the 'shell open' command for the filetype sqlitefile (that both extensions reference)
+$null = New-Item -Path HKCU:\Software\Classes\sqlitefile\shell\open -Force -Name command -Value "$pepys_admin_run_command"
+# Set the default icon for the filetype to the Pepys icon
+$null = New-Item -Path HKCU:\Software\Classes\sqlitefile -Force -Name DefaultIcon -Value $icon_string
+# Refresh the Windows Explorer icon cache, so the icons show immediately
+ie4uinit.exe -show


### PR DESCRIPTION
This PR modifies the install script so that it adds file associations for .sqlite and .db files to be loaded with Pepys Admin. It also assigns them the Pepys icon.

The recommended way of changing file associations in Windows is using the `ftype` and `assoc` commands, but these only work if you have administrator privileges. 'Under the hood' these commands edit the registry, and the relevant part of the registry is available under HKEY_CURRENT_USER and HKEY_CURRENT_MACHINE, with the former being writeable by the current user, and the latter writeable only by administrator. We create the registry keys under HKEY_CURRENT_USER, which means that a normal user should be able to created them (it works on my machine).

**Note**: The extra security policies they have at the client may mean that users are not able to modify file assocations themselves, even in the HKEY_CURRENT_USER part of the registry (sometimes malicious programs try to do this to change file associations to malware) - so this may or may not work for the client, we'll have to test it. If it doesn't work then they can probably do this via Group Policy, but we'd have to talk to the administrator.

@IanMayo: It'd be good if you could test this on your Windows machine, and check it works without admin permissions. Just running the install script should be all you need to do, then try double-clicking on a .sqlite or .db file.

Fixes #526 