### PR TITLE
Hotfix - Increase benchmark time slightly

### DIFF
--- a/tests/benchmarks/test_import_benchmark.py
+++ b/tests/benchmarks/test_import_benchmark.py
@@ -48,7 +48,7 @@ def test_single_rep_file_import_long(benchmark):
         rounds=1,
     )
 
-    TIME_THRESHOLD = 40
+    TIME_THRESHOLD = 44
 
     if running_on_travis():
         if benchmark.stats.stats.mean > TIME_THRESHOLD:


### PR DESCRIPTION
The recent changes to platform resolving increased the time taken for one of our file import benchmarks slightly. The test now passes around 50% of the time, and the other 50% of the time the benchmark takes slightly too long.

This increases the benchmark maximum time by a few seconds, to give us a bit of room for random fluctuations.