### PR TITLE
Make synonym link UI use same display of platform data as rest of UI

### DIFF
--- a/pepys_import/utils/data_store_utils.py
+++ b/pepys_import/utils/data_store_utils.py
@@ -130,8 +130,7 @@ def import_synonyms(data_store, filepath, change_id):
 
 def ask_user_for_synonym_link(data_store, results, values):
     options = [
-        f"{result.name}: Nationality = {result.nationality_name}, Identifier = {result.identifier}"
-        for result in results
+        f"{result.name} / {result.identifier} / {result.nationality_name}" for result in results
     ]
 
     options += ["Skip this row"]


### PR DESCRIPTION
The part of the UI that asked the user to link a synonym displayed the list of platforms in a different way to the rest of the UI. This fixes that so that this part of the UI displays platforms in the `{name} / {identifier} / {nationality}` style that the rest of the UI uses.