### PR TITLE
Remove deprecated isort flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 script:
   - coverage3 run -m pytest tests
   - black --check --diff importers pepys_import pepys_admin
-  - isort --check-only --diff --recursive importers pepys_import pepys_admin
+  - isort --check-only --diff importers pepys_import pepys_admin
 after_success:
   - coverage3 report
   # Push the results back to codecov


### PR DESCRIPTION
I realised that Travis CI builds started to throw a warning because of the new version of `isort`: 
`The following deprecated CLI flags were used: --recursive!` 

This PR removes this flag to solve this issue.