### PR TITLE
Fix bumpversion config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,12 +4,8 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
 
 [bumpversion:file:pepys_import/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/debrief/pepys-import",
-    version='0.0.20',
+    version="0.0.20",
     zip_safe=False,
 )


### PR DESCRIPTION
Bumpversion was using manually-configured search/replace strings for finding the version number to replace, and these led to incorrect results. Actually, the bumpversion defaults work fine for us, so I've removed those config lines, and it uses the defaults.

Fixes #551.
I've also run black on setup.py, as it seemed to have single quotes around the version string rather than black's preferred double quotes.