### PR TITLE
Fix mod_spatialite download URL, and add error handling

### DIFF
--- a/bin/set_paths.bat
+++ b/bin/set_paths.bat
@@ -13,7 +13,7 @@ set PEPYS_PATH_PYTHON_ABS=%CD%
 popd
 
 REM Get absolute path to folder with spatialite DLLs in it
-set PEPYS_PATH_SPATIALITE=..\lib\mod_spatialite-NG-win-amd64
+set PEPYS_PATH_SPATIALITE=..\lib\spatialite-loadable-modules-5.0.0-win-amd64
 pushd %PEPYS_PATH_SPATIALITE%
 set PEPYS_PATH_SPATIALITE_ABS=%CD%
 popd

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -27,8 +27,8 @@ Expand-Archive -Path sqlite.zip -DestinationPath .\python -Force
 Write-Output "INFO: Downloaded and extracted SQLite"
 
 # Download mod_spatialite DLL files
-$url = 'http://www.gaia-gis.it/gaia-sins/windows-bin-NEXTGEN-amd64/mod_spatialite-NG-win-amd64.7z'
-(New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\mod_spatialite.7z")
+$url = 'http://www.gaia-gis.it/gaia-sins/windows-bin-amd64/spatialite-loadable-modules-5.0.0-win-amd64.7z'
+(New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\spatialite-loadable-modules-5.0.0-win-amd64.7z")
 
 # mod_spatialite comes in a 7zip archive, so we need to download 7zip to be able to extract it
 $url = 'http://www.7-zip.org/a/7za920.zip'
@@ -37,7 +37,13 @@ $url = 'http://www.7-zip.org/a/7za920.zip'
 Expand-Archive -Path 7zip.zip -DestinationPath .\7zip -Force
 
 # Extract the mod_spatialite 7zip file into the lib folder (it creates its own subfolder in there)
-.\7zip\7za.exe x .\mod_spatialite.7z -olib -y
+.\7zip\7za.exe x .\spatialite-loadable-modules-5.0.0-win-amd64.7z -olib -y
+
+if ($LastExitCode -ne 0)
+{
+    Write-Output "ERROR: Could not extract spatialite file - has the URL broken?"
+    exit
+}
 
 Write-Output "INFO: Downloaded and extracted mod_spatialite"
 


### PR DESCRIPTION
Fixes #575.

The error in #575 was because Pepys Admin couldn't load mod_spatialite, and the reason it couldn't load it was because the deployment process hadn't downloaded it properly. It turns out that the spatialite website has changed, and the URL we had now returns a 404 error. I've updated the URL, and - because the folder inside the zip file has changed too - I've updated the `set_paths.bat` file.

I've also added error-handling to check if the extraction of spatialite fails, and if so, to stop the deployment script.

This should fix it now - can you check it works for you @IanMayo? (You'll need to clone this PR and then run the create_deployment.bat script, then take the zip and test deploying it).

I will add a separate issue to add more robust error-handling to the deployment process, and the batch files that the user runs.