### PR TITLE
Improve error-handling for deployment and execution batch files

### DIFF
--- a/bin/install_pepys.bat
+++ b/bin/install_pepys.bat
@@ -1,4 +1,10 @@
-@echo off
+@ECHO off
 powershell.exe -executionpolicy remotesigned -File install_pepys.ps1
-echo Shortcuts created and PATH set
+IF ERRORLEVEL 1 GOTO :ERROR
+ECHO Shortcuts created and PATH set
 PAUSE
+
+GOTO :eof
+
+:ERROR
+ECHO Error running install_pepys.ps1

--- a/bin/install_pepys.ps1
+++ b/bin/install_pepys.ps1
@@ -9,7 +9,7 @@ $WshShell = New-Object -comObject WScript.Shell
 # Get the User's Send To folder location
 # This is safer than using a hard-coded PATH as network/user settings may mean the folder
 # is in an unexpected place
-$sendto_location = $WshShell.SpecialFolders("SendTo")
+$sendto_location = $WshShell.SpecialFolders("SendTo2")
 
 # On Windows icons are specified as a path, followed by a comma and a zero-based index into
 # the icons inside the file (as, some files like DLLs can have multiple icons in them)
@@ -20,82 +20,113 @@ $icon_string = "$icon_path,0"
 #
 # Add Pepys Import shortcut to Send To
 #
+try {
+    $shortcut_loc = $sendto_location + "\Pepys Import.lnk"
 
-$shortcut_loc = $sendto_location + "\Pepys Import.lnk"
+    if (Test-Path $shortcut_loc) { Remove-Item $shortcut_loc; }
 
-if (Test-Path $shortcut_loc) { Remove-Item $shortcut_loc; }
+    $Shortcut = $WshShell.CreateShortcut($shortcut_loc)
+    # We need to use full paths here or the shortcut will assume everything is relative to
+    # C:\
+    $Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_import_sendto.bat")
+    $Shortcut.IconLocation = $icon_string
+    # If we don't set the working directory then we won't be able to import other DLLs or use relative paths
+    # to our Python executable
+    $Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
+    $Shortcut.Save()
+}
+catch {
+    Write-Output "ERROR: Could not create Pepys Import Send-To Shortcut"
+    Exit 1
+}
 
-$Shortcut = $WshShell.CreateShortcut($shortcut_loc)
-# We need to use full paths here or the shortcut will assume everything is relative to
-# C:\
-$Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_import_sendto.bat")
-$Shortcut.IconLocation = $icon_string
-# If we don't set the working directory then we won't be able to import other DLLs or use relative paths
-# to our Python executable
-$Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
-$Shortcut.Save()
 
 
 #
 # Add Pepys Import (no archive) shortcut to Send To
 #
+try {
+    $shortcut_loc = $sendto_location + "\Pepys Import (no archive).lnk"
 
-$shortcut_loc = $sendto_location + "\Pepys Import (no archive).lnk"
+    if (Test-Path $shortcut_loc) { Remove-Item $shortcut_loc; }
 
-if (Test-Path $shortcut_loc) { Remove-Item $shortcut_loc; }
+    $Shortcut = $WshShell.CreateShortcut($shortcut_loc)
+    $Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_import_no_archive_sendto.bat")
+    $Shortcut.IconLocation = $icon_string
+    $Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
+    $Shortcut.Save()
 
-$Shortcut = $WshShell.CreateShortcut($shortcut_loc)
-$Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_import_no_archive_sendto.bat")
-$Shortcut.IconLocation = $icon_string
-$Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
-$Shortcut.Save()
+}
+catch {
+    Write-Output "ERROR: Could not create Pepys Import (no archive) Send-To Shortcut"
+    Exit 1
+}
 
 #
 # Add shortcut to Start Menu
 #
+try {
+    # Get the User's Start Menu folder
+    $startmenu_location = "$env:USERPROFILE\Start Menu\Programs\"
 
-# Get the User's Start Menu folder
-$startmenu_location = "$env:USERPROFILE\Start Menu\Programs\"
+    # Delete Pepys folder in Start Menu if it exists
+    $pepys_folder = $startmenu_location + "\Pepys"
 
-# Delete Pepys folder in Start Menu if it exists
-$pepys_folder = $startmenu_location + "\Pepys"
+    if (Test-Path $pepys_folder) { Remove-Item $pepys_folder -Recurse ; }
 
-if (Test-Path $pepys_folder) { Remove-Item $pepys_folder -Recurse ; }
+    # Create Pepys folder in Start Menu
+    New-Item -Path $startmenu_location -Name "Pepys" -ItemType "directory"
 
-# Create Pepys folder in Start Menu
-New-Item -Path $startmenu_location -Name "Pepys" -ItemType "directory"
+    $Shortcut = $WshShell.CreateShortcut($startmenu_location + "Pepys\Pepys Admin.lnk")
+    $Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_admin.bat")
+    $Shortcut.IconLocation = $icon_string
+    $Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
+    $Shortcut.Save()
+}
+catch {
+    Write-Output "ERROR: Could not create Pepys Admin Start Menu shortcut"
+    Exit 1
+}
 
-$Shortcut = $WshShell.CreateShortcut($startmenu_location + "Pepys\Pepys Admin.lnk")
-$Shortcut.TargetPath = [System.IO.Path]::GetFullPath(".\pepys_admin.bat")
-$Shortcut.IconLocation = $icon_string
-$Shortcut.WorkingDirectory = [System.IO.Path]::GetFullPath(".")
-$Shortcut.Save()
 
 #
 # Add Pepys bin folder to User's PATH variable
 #
-$pepys_bin_path = [System.IO.Path]::GetFullPath(".")
+try {
+    $pepys_bin_path = [System.IO.Path]::GetFullPath(".")
 
-if (!($env:Path -split ';' -contains $pepys_bin_path)) {
-    [Environment]::SetEnvironmentVariable(
-        "PATH",
-        [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User) + ";" + $pepys_bin_path,
-        [EnvironmentVariableTarget]::User)
+    if (!($env:Path -split ';' -contains $pepys_bin_path)) {
+        [Environment]::SetEnvironmentVariable(
+            "PATH",
+            [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User) + ";" + $pepys_bin_path,
+            [EnvironmentVariableTarget]::User)
+    }
+}
+catch {
+    Write-Output "ERROR: Could not add Pepys bin folder to user's PATH"
+    Exit 1
 }
 
-# Create file associations for .sqlite and .db files to open in Pepys Admin
-$pepys_admin_run_command = [System.IO.Path]::GetFullPath(".\pepys_admin.bat") + " --db %1"
 
-# All of the assigning to $null below is just to stop the default output showing exactly
-# what registry keys have been created
+try {
+    # Create file associations for .sqlite and .db files to open in Pepys Admin
+    $pepys_admin_run_command = [System.IO.Path]::GetFullPath(".\pepys_admin.bat") + " --db %1"
 
-# Create the file extension entry for .sqlite and assign it to the filetype sqlitefile
-$null = New-Item -Path HKCU:\Software\Classes -Name .sqlite -Value sqlitefile -Force
-# Do the same for the .db extension
-$null = New-Item -Path HKCU:\Software\Classes -Name .db -Value sqlitefile -Force
-# Specify the 'shell open' command for the filetype sqlitefile (that both extensions reference)
-$null = New-Item -Path HKCU:\Software\Classes\sqlitefile\shell\open -Force -Name command -Value "$pepys_admin_run_command"
-# Set the default icon for the filetype to the Pepys icon
-$null = New-Item -Path HKCU:\Software\Classes\sqlitefile -Force -Name DefaultIcon -Value $icon_string
-# Refresh the Windows Explorer icon cache, so the icons show immediately
-ie4uinit.exe -show
+    # All of the assigning to $null below is just to stop the default output showing exactly
+    # what registry keys have been created
+
+    # Create the file extension entry for .sqlite and assign it to the filetype sqlitefile
+    $null = New-Item -Path HKCU:\Software\Classes -Name .sqlite -Value sqlitefile -Force
+    # Do the same for the .db extension
+    $null = New-Item -Path HKCU:\Software\Classes -Name .db -Value sqlitefile -Force
+    # Specify the 'shell open' command for the filetype sqlitefile (that both extensions reference)
+    $null = New-Item -Path HKCU:\Software\Classes\sqlitefile\shell\open -Force -Name command -Value "$pepys_admin_run_command"
+    # Set the default icon for the filetype to the Pepys icon
+    $null = New-Item -Path HKCU:\Software\Classes\sqlitefile -Force -Name DefaultIcon -Value $icon_string
+    # Refresh the Windows Explorer icon cache, so the icons show immediately
+    ie4uinit.exe -show
+}
+catch {
+    Write-Output "ERROR: Could not create file assocations"
+    Exit 1
+}

--- a/bin/install_pepys.ps1
+++ b/bin/install_pepys.ps1
@@ -36,6 +36,7 @@ try {
     $Shortcut.Save()
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not create Pepys Import Send-To Shortcut"
     Exit 1
 }
@@ -58,6 +59,7 @@ try {
 
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not create Pepys Import (no archive) Send-To Shortcut"
     Exit 1
 }
@@ -84,6 +86,7 @@ try {
     $Shortcut.Save()
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not create Pepys Admin Start Menu shortcut"
     Exit 1
 }
@@ -103,6 +106,7 @@ try {
     }
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not add Pepys bin folder to user's PATH"
     Exit 1
 }
@@ -127,6 +131,7 @@ try {
     ie4uinit.exe -show
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not create file assocations"
     Exit 1
 }

--- a/bin/install_pepys.ps1
+++ b/bin/install_pepys.ps1
@@ -9,7 +9,7 @@ $WshShell = New-Object -comObject WScript.Shell
 # Get the User's Send To folder location
 # This is safer than using a hard-coded PATH as network/user settings may mean the folder
 # is in an unexpected place
-$sendto_location = $WshShell.SpecialFolders("SendTo2")
+$sendto_location = $WshShell.SpecialFolders("SendTo")
 
 # On Windows icons are specified as a path, followed by a comma and a zero-based index into
 # the icons inside the file (as, some files like DLLs can have multiple icons in them)

--- a/bin/pepys_admin.bat
+++ b/bin/pepys_admin.bat
@@ -1,4 +1,14 @@
 @echo off
 CALL set_paths.bat
+REM If error returned from set_paths.bat then don't continue with running python
+IF ERRORLEVEL 1 GOTO :ERROR
+
 python -m pepys_admin.cli %1 %2 %3 %4 %5 %6 %7 %8 %9
+PAUSE
+
+REM Go to the end of the file, skipping the :ERROR label below
+GOTO :eof
+
+REM PAUSE so that the user can see the error
+:ERROR
 PAUSE

--- a/bin/pepys_import.bat
+++ b/bin/pepys_import.bat
@@ -1,3 +1,12 @@
 @echo off
 CALL set_paths.bat
+REM If error returned from set_paths.bat then don't continue with running python
+IF ERRORLEVEL 1 GOTO :ERROR
 python -m pepys_import.cli %1 %2 %3 %4 %5 %6 %7 %8 %9
+
+REM Go to the end of the file, skipping the :ERROR label below
+GOTO :eof
+
+REM PAUSE so that the user can see the error
+:ERROR
+PAUSE

--- a/bin/pepys_import_no_archive_sendto.bat
+++ b/bin/pepys_import_no_archive_sendto.bat
@@ -1,6 +1,16 @@
 @echo off
 CALL set_paths.bat
+REM If error returned from set_paths.bat then don't continue with running python
+IF ERRORLEVEL 1 GOTO :ERROR
+
 REM note: when we're called via the "SendTo" link, the target is in the first argument
 python -m pepys_import.cli --path %1 %2 %3 %4 %5 %6 %7 %8
 REM we're pausing the end of the script so we learn more about what is being processed
+PAUSE
+
+REM Go to the end of the file, skipping the :ERROR label below
+GOTO :eof
+
+REM PAUSE so that the user can see the error
+:ERROR
 PAUSE

--- a/bin/pepys_import_sendto.bat
+++ b/bin/pepys_import_sendto.bat
@@ -1,6 +1,16 @@
 @echo off
 CALL set_paths.bat
+REM If error returned from set_paths.bat then don't continue with running python
+IF ERRORLEVEL 1 GOTO :ERROR
+
 REM note: when we're called via the "SendTo" link, the target is in the first argument
 python -m pepys_import.cli --archive --path %1 %2 %3 %4 %5 %6 %7 %8
 REM we're pausing the end of the script so we learn more about what is being processed
+PAUSE
+
+REM Go to the end of the file, skipping the :ERROR label below
+GOTO :eof
+
+REM PAUSE so that the user can see the error
+:ERROR
 PAUSE

--- a/bin/run_python.bat
+++ b/bin/run_python.bat
@@ -1,2 +1,12 @@
-call set_paths.bat
+@echo off
+CALL set_paths.bat
+REM If error returned from set_paths.bat then don't continue with running python
+IF ERRORLEVEL 1 GOTO :ERROR
 ..\python\python.exe %1 %2 %3 %4 %5 %6 %7 %8 %9
+
+REM Go to the end of the file, skipping the :ERROR label below
+GOTO :eof
+
+REM PAUSE so that the user can see the error
+:ERROR
+PAUSE

--- a/bin/set_paths.bat
+++ b/bin/set_paths.bat
@@ -4,6 +4,7 @@ REM Change to the directory that this batch file is in
 REM storing the original directory so we can get back to it
 set orig_path=%cd%
 cd /D "%~dp0"
+if ERRORLEVEL 1 goto :ERROR_CD
 
 
 REM Get absolute path to folder with python executable in it
@@ -11,12 +12,14 @@ set PEPYS_PATH_PYTHON=..\python
 pushd %PEPYS_PATH_PYTHON%
 set PEPYS_PATH_PYTHON_ABS=%CD%
 popd
+if ERRORLEVEL 1 goto :ERROR_PYPATH
 
 REM Get absolute path to folder with spatialite DLLs in it
 set PEPYS_PATH_SPATIALITE=..\lib\spatialite-loadable-modules-5.0.0-win-amd64
 pushd %PEPYS_PATH_SPATIALITE%
 set PEPYS_PATH_SPATIALITE_ABS=%CD%
 popd
+if ERRORLEVEL 1 goto :ERROR_SLPATH
 
 REM Set PATH env var to include those absolute paths
 set PATH=%PEPYS_PATH_PYTHON_ABS%;%PEPYS_PATH_SPATIALITE_ABS%;%PATH%
@@ -26,8 +29,29 @@ set PEPYS_PATH_PYTHON=
 set PEPYS_PATH_PYTHON_ABS=
 set PEPYS_PATH_SPATIALITE=
 set PEPYS_PATH_SPATIALITE_ABS=
+if ERRORLEVEL 1 goto :ERROR_SETVARS
 
 REM Go back to the directory the user was in before we ran this script
 cd %orig_path%
+if ERRORLEVEL 1 goto :ERROR_CD
 
 echo Successfully set paths for Pepys
+
+REM Go to the end of the file - ie. skip the labels below
+goto :eof
+
+:ERROR_CD
+echo ERROR: Couldn't change to correct directory
+goto :eof
+
+:ERROR_PYPATH
+echo ERROR: Cannot find Python path
+goto :eof
+
+:ERROR_SLPATH
+echo ERROR: Cannot find spatialite path
+goto :eof
+
+:ERROR_SETVARS
+echo ERROR: Couldn't set PATH variable or clear other variables
+goto :eof

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -1,57 +1,126 @@
 Write-Output "INFO: Starting to create Pepys deployment"
 
 # Download embedded Python distribution
-$url = 'https://www.python.org/ftp/python/3.7.6/python-3.7.6-embed-amd64.zip'
-(New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\python.zip")
-
-# Extract zip file
-Expand-Archive -Path python.zip -DestinationPath .\python -Force
-Write-Output "INFO: Downloaded and extracted embedded Python"
-
-# Download and run get-pip to install pip
-$url = 'https://bootstrap.pypa.io/get-pip.py'
-(New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\get-pip.py")
-
-.\python\python.exe .\get-pip.py --no-warn-script-location
-
-Write-Output "INFO: Installed pip"
-
-# Download SQLite DLL
-$url = 'https://www.sqlite.org/2020/sqlite-dll-win64-x64-3310100.zip'
-(New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\sqlite.zip")
-
-# Extract SQLite DLL to Python folder, deliberately overwriting sqlite3.dll provided by Python
-# (note the -Force argument, to force overwriting)
-Expand-Archive -Path sqlite.zip -DestinationPath .\python -Force
-
-Write-Output "INFO: Downloaded and extracted SQLite"
-
-# Download mod_spatialite DLL files
-$url = 'http://www.gaia-gis.it/gaia-sins/windows-bin-amd64/spatialite-loadable-modules-5.0.0-win-amd64.7z'
-(New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\spatialite-loadable-modules-5.0.0-win-amd64.7z")
-
-# mod_spatialite comes in a 7zip archive, so we need to download 7zip to be able to extract it
-$url = 'http://www.7-zip.org/a/7za920.zip'
-(New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\7zip.zip")
-# Put the 7zip exe in the .\7zip folder - we will delete this later
-Expand-Archive -Path 7zip.zip -DestinationPath .\7zip -Force
-
-# Extract the mod_spatialite 7zip file into the lib folder (it creates its own subfolder in there)
-.\7zip\7za.exe x .\spatialite-loadable-modules-5.0.0-win-amd64.7z -olib -y
-
-if ($LastExitCode -ne 0)
-{
-    Write-Output "ERROR: Could not extract spatialite file - has the URL broken?"
-    exit
+try {
+    $url = 'https://www.python.org/ftp/python/3.7.6/python-3.7.6-embed-amd64.zip'
+    (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\python.zip")
+}
+catch {
+    Write-Output "ERROR: Could not download embedded Python - has the URL changed?"
+    Exit
 }
 
-Write-Output "INFO: Downloaded and extracted mod_spatialite"
+try {
+    # Extract zip file
+    Expand-Archive -Path python.zip -DestinationPath .\python -Force
+    Write-Output "INFO: Downloaded and extracted embedded Python"
+}
+catch {
+    Write-Output "ERROR: Could not extract Python zip file"
+    Exit
+}
 
-# Set the Python Path file to tell it where to find modules - including the new pip location and
-# the directory above the python folder (with pepys-import in it). This creates a ._pth file which
-# Python uses as it's *only* source for generating sys.path (ie. it does NOT take into account
-# environment variables such as PYTHONPATH)
-Set-Content -Encoding ascii .\python\python37._pth @"
+try {
+    # Download get-pip script
+    $url = 'https://bootstrap.pypa.io/get-pip.py'
+    (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\get-pip.py")
+}
+catch {
+    Write-Output "ERROR: Could not download get-pip.py - has the URL changed?"
+    Exit
+}
+
+# Try-Catch block catches error finding/running the exe file
+# if ($LastExitCode) block catches error from the python.exe itself
+try {
+    # Install pip
+    .\python\python.exe .\get-pip.py --no-warn-script-location 
+
+    if ($LastExitCode -ne 0)
+    {
+        Write-Output "ERROR: Could not install pip"
+        Exit
+    }
+    Write-Output "INFO: Installed pip"
+}
+catch {
+    Write-Output "ERROR: Could not run Python to install pip"
+    Exit
+}
+
+try {
+    # Download SQLite DLL
+    $url = 'https://www.sqlite.org/2020/sqlite-dll-win64-x64-3310100.zip'
+    (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\sqlite.zip")
+}
+catch {
+    Write-Output "ERROR: Could not download SQLite - has the URL changed?"
+    Exit
+}
+
+try {
+    # Extract SQLite DLL to Python folder, deliberately overwriting sqlite3.dll provided by Python
+    # (note the -Force argument, to force overwriting)
+    Expand-Archive -Path sqlite.zip -DestinationPath .\python -Force
+    Write-Output "INFO: Downloaded and extracted SQLite"
+}
+catch {
+    Write-Output "ERROR: Could not extract SQLite zip file"
+    Exit
+}
+
+try {
+    # Download mod_spatialite DLL files
+    $url = 'http://www.gaia-gis.it/gaia-sins/windows-bin-amd64/spatialite-loadable-modules-5.0.0-win-amd64.7z'
+    (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\spatialite-loadable-modules-5.0.0-win-amd64.7z")
+}
+catch {
+    Write-Output "ERROR: Could not download Spatialite - has the URL changed?"
+    Exit
+}
+
+try {
+    # mod_spatialite comes in a 7zip archive, so we need to download 7zip to be able to extract it
+    $url = 'http://www.7-zip.org/a/7za920.zip'
+    (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\7zip.zip")
+}
+catch {
+    Write-Output "ERROR: Could not download 7zip - has the URL changed?"
+    Exit
+}
+
+try {
+    # Put the 7zip exe in the .\7zip folder - we will delete this later
+    Expand-Archive -Path 7zip.zip -DestinationPath .\7zip -Force
+}
+catch {
+    Write-Output "ERROR: Could not extract 7zip"
+    Exit
+}
+
+try {
+    # Extract the mod_spatialite 7zip file into the lib folder (it creates its own subfolder in there)
+    .\7zip\7za.exe x .\spatialite-loadable-modules-5.0.0-win-amd64.7z -olib -y
+
+    if ($LastExitCode -ne 0)
+    {
+        Write-Output "ERROR: Could not extract spatialiate"
+        Exit
+    }
+    Write-Output "INFO: Downloaded and extracted mod_spatialite"
+}
+catch {
+    Write-Output "ERROR: Could not run 7zip to extract spatialite"
+    Exit
+}
+
+
+try {
+    # Set the Python Path file to tell it where to find modules - including the new pip location and
+    # the directory above the python folder (with pepys-import in it). This creates a ._pth file which
+    # Python uses as it's *only* source for generating sys.path (ie. it does NOT take into account
+    # environment variables such as PYTHONPATH)
+    Set-Content -Encoding ascii .\python\python37._pth @"
 python37.zip
 .
 Lib\site-packages
@@ -59,40 +128,95 @@ Lib\site-packages
 import site
 "@
 
-Set-Content -Encoding ascii .\python\Lib\site-packages\extra_paths.pth @"
+    Set-Content -Encoding ascii .\python\Lib\site-packages\extra_paths.pth @"
 import sys; sys.path.insert(0, "")
 pip\_vendor\pep517
 "@
 
 
-Write-Output "INFO: Set Python pth files"
+    Write-Output "INFO: Set Python pth files"
+}
+catch {
+    Write-Output "ERROR: Could not write to path files"
+    Exit
+}
 
-# Do a standard pip install of the requirements and dev requirements, not warning us that scripts will be unavailable
-.\python\python.exe -m pip install -r requirements.txt -r requirements_dev.txt --no-warn-script-location --no-cache-dir
+try {
+    # Do a standard pip install of the requirements and dev requirements, not warning us that scripts will be unavailable
+    .\python\python.exe -m pip install -r requirements.txt -r requirements_dev.txt --no-warn-script-location --no-cache-dir
 
-Write-Output "INFO: Installed Python dependencies"
+    if ($LastExitCode -ne 0)
+    {
+        Write-Output "ERROR: Problem installing dependencies using pip"
+        Exit
+    }
 
-Remove-Item *.zip
-Remove-Item *.7z
-Remove-Item get-pip.py
+    Write-Output "INFO: Installed Python dependencies"
+}
+catch {
+    Write-Output "ERROR: Could not run Python to install requirements using pip"
+    Exit
+}
 
-Write-Output "INFO: Cleaned up all except 7zip"
+
+try {
+    Remove-Item *.zip
+    Remove-Item *.7z
+    Remove-Item get-pip.py
+
+    Write-Output "INFO: Cleaned up all except 7zip"
+}
+catch {
+    Write-Output "ERROR: Could not delete old deployment files"
+    Exit
+}
+
 
 Write-Output "INFO: Building documentation"
-# Write to the same folder that 'make html' does, so it works for devs who've done that on other platforms
-.\python\Scripts\sphinx-build.exe docs docs\_build\html
+try {
+    # Write to the same folder that 'make html' does, so it works for devs who've done that on other platforms
+    .\python\Scripts\sphinx-build.exe docs docs\_build\html
 
-write-Output "INFO: Finished building documentation"
+    if ($LastExitCode -ne 0)
+    {
+        Write-Output "ERROR: Problem running sphinx-build.exe to build docs"
+        Exit
+    }
+    write-Output "INFO: Finished building documentation"
+}
+catch {
+    Write-Output "ERROR: Could not run sphinx-build.exe to build docs"
+    Exit
+}
 
-# Zip up whole folder into a zip-file with the current date in the filename
-# excluding the 7zip folder
-$date_str = Get-Date -Format "yyyyMMdd"
-$output_filename = $date_str + "_pepys-import.zip"
-.\7zip\7za.exe a .\$output_filename .\* -xr!7zip/ -xr!"bin\distlib-0.3.0-py2.py3-none-any.whl"
+try {
+    # Zip up whole folder into a zip-file with the current date in the filename
+    # excluding the 7zip folder
+    $date_str = Get-Date -Format "yyyyMMdd"
+    $output_filename = $date_str + "_pepys-import.zip"
+    .\7zip\7za.exe a .\$output_filename .\* -xr!7zip/ -xr!"bin\distlib-0.3.0-py2.py3-none-any.whl"
 
-Write-Output "INFO: Written zipped deployment file to $output_filename"
+    if ($LastExitCode -ne 0)
+    {
+        Write-Output "ERROR: Error returned from running 7zip to create final deployment file"
+        Exit
+    }
 
-# Remove folders/files that we don't need any more
-Remove-Item .\7zip -Recurse
+    Write-Output "INFO: Written zipped deployment file to $output_filename"
+}
+catch {
+    Write-Output "ERROR: Could not run 7zip to create final deployment file"
+    Exit
+}
 
-Write-Output "INFO: Finished cleanup"
+
+try {
+    # Remove folders/files that we don't need any more
+    Remove-Item .\7zip -Recurse
+
+    Write-Output "INFO: Finished cleanup"
+}
+catch {
+    Write-Output "ERROR: Could not remove items in final cleanup"
+    Exit
+}

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -6,6 +6,7 @@ try {
     (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\python.zip")
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not download embedded Python - has the URL changed?"
     Exit
 }
@@ -16,6 +17,7 @@ try {
     Write-Output "INFO: Downloaded and extracted embedded Python"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not extract Python zip file"
     Exit
 }
@@ -26,6 +28,7 @@ try {
     (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\get-pip.py")
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not download get-pip.py - has the URL changed?"
     Exit
 }
@@ -44,6 +47,7 @@ try {
     Write-Output "INFO: Installed pip"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not run Python to install pip"
     Exit
 }
@@ -54,6 +58,7 @@ try {
     (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\sqlite.zip")
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not download SQLite - has the URL changed?"
     Exit
 }
@@ -65,6 +70,7 @@ try {
     Write-Output "INFO: Downloaded and extracted SQLite"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not extract SQLite zip file"
     Exit
 }
@@ -75,6 +81,7 @@ try {
     (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\spatialite-loadable-modules-5.0.0-win-amd64.7z")
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not download Spatialite - has the URL changed?"
     Exit
 }
@@ -85,6 +92,7 @@ try {
     (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\7zip.zip")
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not download 7zip - has the URL changed?"
     Exit
 }
@@ -94,6 +102,7 @@ try {
     Expand-Archive -Path 7zip.zip -DestinationPath .\7zip -Force
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not extract 7zip"
     Exit
 }
@@ -110,6 +119,7 @@ try {
     Write-Output "INFO: Downloaded and extracted mod_spatialite"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not run 7zip to extract spatialite"
     Exit
 }
@@ -137,6 +147,7 @@ pip\_vendor\pep517
     Write-Output "INFO: Set Python pth files"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not write to path files"
     Exit
 }
@@ -154,6 +165,7 @@ try {
     Write-Output "INFO: Installed Python dependencies"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not run Python to install requirements using pip"
     Exit
 }
@@ -167,6 +179,7 @@ try {
     Write-Output "INFO: Cleaned up all except 7zip"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not delete old deployment files"
     Exit
 }
@@ -185,6 +198,7 @@ try {
     write-Output "INFO: Finished building documentation"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not run sphinx-build.exe to build docs"
     Exit
 }
@@ -205,6 +219,7 @@ try {
     Write-Output "INFO: Written zipped deployment file to $output_filename"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not run 7zip to create final deployment file"
     Exit
 }
@@ -217,6 +232,7 @@ try {
     Write-Output "INFO: Finished cleanup"
 }
 catch {
+    Write-Output $_
     Write-Output "ERROR: Could not remove items in final cleanup"
     Exit
 }


### PR DESCRIPTION
This PR improves error handling in our Powershell and batch files. Specifically, it:

 - Adds significant error handling to the `create_deployment.ps1` file, so that we now get alerted to any errors creating the deployment, and the deployment stops as soon as it encounters an error. This should significantly reduce the likelihood of creating an invalid deployment zip file
 - Adds error handling to the `set_paths.bat` file, so that if required paths are not found (due either to an invalid deployment zip, or a failed deployment) then it exits with errors
 - Adds error handling to all of the other batch files, like `pepys_import.bat` and `pepys_admin.bat` to catch errors that come from `set_paths.bat` and then stop before running any of the Pepys code. This means the user will get an error from `set_paths.bat` and then the program will stop (using the `PAUSE` command to print a 'Press Any Key to Continue' message). Thus, the user will know about the error immediately, and not run into problems in the Pepys Python code itself.