### PR TITLE
Delete Datafile entry if there have been errors importing the file

### DIFF
--- a/pepys_import/file/file_processor.py
+++ b/pepys_import/file/file_processor.py
@@ -341,6 +341,11 @@ class FileProcessor:
                 import_summary["succeeded"].append(summary_details)
 
             else:
+                # Delete the datafile entry, as we won't be importing any entries
+                # linked to it, because we had errors
+                data_store.session.delete(datafile)
+                data_store.session.commit()
+
                 failure_report_filename = os.path.join(
                     self.directory_path, f"{filename}_errors.log"
                 )

--- a/tests/config_file_tests/test_local_and_core_validators.py
+++ b/tests/config_file_tests/test_local_and_core_validators.py
@@ -170,7 +170,7 @@ class TestLocalTestsFails(unittest.TestCase):
             platforms = self.store.session.query(self.store.db_classes.Platform).all()
             self.assertEqual(len(platforms), 18)
 
-            # there must be one datafile afterwards
+            # there must be no datafiles afterwards - as all files gave errors
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
             self.assertEqual(len(datafiles), 0)
 
@@ -210,7 +210,7 @@ class TestLocalTestsFails(unittest.TestCase):
             platforms = self.store.session.query(self.store.db_classes.Platform).all()
             self.assertEqual(len(platforms), 2)
 
-            # there must be one datafile afterwards
+            # there must be no datafiles afterwards - as all files gave errors
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
             self.assertEqual(len(datafiles), 0)
 

--- a/tests/config_file_tests/test_local_and_core_validators.py
+++ b/tests/config_file_tests/test_local_and_core_validators.py
@@ -172,7 +172,7 @@ class TestLocalTestsFails(unittest.TestCase):
 
             # there must be one datafile afterwards
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
-            self.assertEqual(len(datafiles), 1)
+            self.assertEqual(len(datafiles), 0)
 
     @patch("config.LOCAL_BASIC_TESTS", BASIC_PARSERS_FAILS_PATH)
     @patch("config.LOCAL_ENHANCED_TESTS", ENHANCED_PARSERS_FAILS_PATH)
@@ -212,7 +212,7 @@ class TestLocalTestsFails(unittest.TestCase):
 
             # there must be one datafile afterwards
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
-            self.assertEqual(len(datafiles), 1)
+            self.assertEqual(len(datafiles), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_admin_cli.py
+++ b/tests/test_admin_cli.py
@@ -90,7 +90,7 @@ class AdminCLITestCase(unittest.TestCase):
         states_text = "| States       |              738 |"
         contacts_text = "| Contacts     |              110 |"
         comments_text = "| Comments     |                7 |"
-        datafiles_text = "| Datafiles    |                8 |"
+        datafiles_text = "| Datafiles    |                5 |"
         assert states_text in output
         assert contacts_text in output
         assert comments_text in output

--- a/tests/test_load_etrac.py
+++ b/tests/test_load_etrac.py
@@ -51,7 +51,7 @@ class TestLoadEtrac(unittest.TestCase):
 
             # there must be one datafile afterwards
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
-            self.assertEqual(len(datafiles), 2)
+            self.assertEqual(len(datafiles), 1)
 
             # Check that there is an elevation of 147 reported (test file was manually edited
             # to contain an elevation of 147m)

--- a/tests/test_load_gpx.py
+++ b/tests/test_load_gpx.py
@@ -50,7 +50,7 @@ class GPXTests(unittest.TestCase):
 
             # there must be one datafile afterwards
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
-            assert len(datafiles) == 7
+            assert len(datafiles) == 4
 
             #
             # Test the actual values that are imported

--- a/tests/test_load_rep.py
+++ b/tests/test_load_rep.py
@@ -53,7 +53,7 @@ class TestLoadREP(unittest.TestCase):
 
             # there must be one datafile afterwards
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
-            self.assertEqual(len(datafiles), 8)
+            self.assertEqual(len(datafiles), 6)
 
             # There should be one state with no elevation, which comes from the NaN
             # in the elevation field in the first line of uk_track.rep
@@ -113,7 +113,7 @@ class TestLoadREP(unittest.TestCase):
 
             # there must be one datafile afterwards
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
-            self.assertEqual(len(datafiles), 8)
+            self.assertEqual(len(datafiles), 7)
 
             # There should be one state with no elevation, which comes from the NaN
             # in the elevation field in the first line of uk_track.rep

--- a/tests/test_load_rep_comment.py
+++ b/tests/test_load_rep_comment.py
@@ -91,7 +91,7 @@ class RepCommentTests(unittest.TestCase):
 
         # check data got created
         with self.store.session_scope():
-            # there must be states after the import
+            # there must be no states after the import
             comments = self.store.session.query(self.store.db_classes.Comment).all()
             self.assertEqual(len(comments), 0)
 
@@ -99,9 +99,9 @@ class RepCommentTests(unittest.TestCase):
             platforms = self.store.session.query(self.store.db_classes.Platform).all()
             self.assertEqual(len(platforms), 2)
 
-            # there must be one datafile afterwards
+            # there must be no datafiles afterwards - because the file was invalid
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
-            self.assertEqual(len(datafiles), 1)
+            self.assertEqual(len(datafiles), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_view_data_cli.py
+++ b/tests/test_view_data_cli.py
@@ -37,10 +37,8 @@ class ViewDataCLITestCase(unittest.TestCase):
         print(output)
         assert "Datafiles\n" in output
         assert "| datafile_type_name   | reference                        | url   |\n" in output
-        assert "| E-Trac               | e_trac_bad.txt                   | None  |\n" in output
         assert "| E-Trac               | e_trac.txt                       | None  |\n" in output
         assert "| EAG                  | 20200305_ROBIN.eag.txt           | None  |" in output
-        assert "| NMEA                 | NMEA_bad.log                     | None  |" in output
 
     @patch("pepys_admin.view_data_cli.iterfzf", return_value="alembic_version")
     def test_do_view_table_alembic_version(self, patched_input):
@@ -68,7 +66,6 @@ class ViewDataCLITestCase(unittest.TestCase):
                     "datafile_id,simulated,privacy_id,datafile_type_id,reference,url,size,hash,created_date\n"
                     in data
                 )
-                assert "e_trac_bad.txt,,5261,7bbe513d9d253d2277435e0849ed8342" in data
                 assert "20200305_ROBIN.eag.txt,,386,f3d0a8a1760f312ea57912548b48b766" in data
                 assert (
                     "20200305_ROBINWithHeader.eag.txt,,479,ec2694c2cfe2eaa26181999a55aee5b4" in data
@@ -103,15 +100,7 @@ class ViewDataCLITestCase(unittest.TestCase):
         print(output)
         assert "SELECT * FROM Datafiles;" in output
         assert (
-            "| e_trac_bad.txt                   | None | 5261 | 7bbe513d9d253d2277435e0849ed8342"
-            in output
-        )
-        assert (
             "| e_trac.txt                       | None | 5315 | 577fad568cda2eb0b24178f5554f2b46"
-            in output
-        )
-        assert (
-            "| NMEA_bad.log                     | None |  243 | b201a229fb2c4a80bd657066e4bf9c8a"
             in output
         )
 
@@ -137,7 +126,6 @@ class ViewDataCLITestCase(unittest.TestCase):
             with open(path, "r") as f:
                 data = f.read()
                 assert "Executed Query: SELECT * FROM Datafiles;" in data
-                assert "e_trac_bad.txt,,5261,7bbe513d9d253d2277435e0849ed8342" in data
                 assert "20200305_ROBIN.eag.txt,,386,f3d0a8a1760f312ea57912548b48b766" in data
                 assert (
                     "20200305_ROBINWithHeader.eag.txt,,479,ec2694c2cfe2eaa26181999a55aee5b4" in data
@@ -237,10 +225,8 @@ class ViewDataCLIPostgresTestCase(unittest.TestCase):
         print(output)
         assert "Datafiles\n" in output
         assert "| datafile_type_name   | reference                        | url   |\n" in output
-        assert "| E-Trac               | e_trac_bad.txt                   | None  |\n" in output
         assert "| E-Trac               | e_trac.txt                       | None  |\n" in output
         assert "| EAG                  | 20200305_ROBIN.eag.txt           | None  |" in output
-        assert "| NMEA                 | NMEA_bad.log                     | None  |" in output
 
     @patch("pepys_admin.view_data_cli.iterfzf", return_value="alembic_version")
     def test_do_view_table_alembic_version(self, patched_input):
@@ -268,7 +254,6 @@ class ViewDataCLIPostgresTestCase(unittest.TestCase):
                     "datafile_id,simulated,privacy_id,datafile_type_id,reference,url,size,hash,created_date\n"
                     in data
                 )
-                assert "e_trac_bad.txt,,5261,7bbe513d9d253d2277435e0849ed8342" in data
                 assert "20200305_ROBIN.eag.txt,,386,f3d0a8a1760f312ea57912548b48b766" in data
                 assert (
                     "20200305_ROBINWithHeader.eag.txt,,479,ec2694c2cfe2eaa26181999a55aee5b4" in data
@@ -303,15 +288,7 @@ class ViewDataCLIPostgresTestCase(unittest.TestCase):
         print(output)
         assert 'SELECT * FROM "pepys"."Datafiles";' in output
         assert (
-            "| e_trac_bad.txt                   | None | 5261 | 7bbe513d9d253d2277435e0849ed8342"
-            in output
-        )
-        assert (
             "| e_trac.txt                       | None | 5315 | 577fad568cda2eb0b24178f5554f2b46"
-            in output
-        )
-        assert (
-            "| NMEA_bad.log                     | None |  243 | b201a229fb2c4a80bd657066e4bf9c8a"
             in output
         )
 
@@ -341,7 +318,6 @@ class ViewDataCLIPostgresTestCase(unittest.TestCase):
                 assert (
                     "20200305_ROBINWithHeader.eag.txt,,479,ec2694c2cfe2eaa26181999a55aee5b4" in data
                 )
-                assert "e_trac_bad.txt,,5261,7bbe513d9d253d2277435e0849ed8342" in data
                 assert "e_trac.txt,,5315,577fad568cda2eb0b24178f5554f2b46" in data
 
             os.remove(path)


### PR DESCRIPTION
This fixes #587 by deleting the Datafile entry if there were errors importing the file. This means we don't have 'orphan' Datafile entries hanging around - which potentially causes problems for re-importing files with errors.

The actual change is about two lines long (just a call to a delete function) - the majority of the PR is fixing the tests as the number of datafiles has changed.