### PR TITLE
Make option validation dynamic for platform resolver

### DIFF
--- a/pepys_import/resolvers/command_line_resolver.py
+++ b/pepys_import/resolvers/command_line_resolver.py
@@ -145,10 +145,14 @@ class CommandLineResolver(DataResolver):
                 )
             final_options[1] += f", default name '{platform_name}'"
         choices = platform_details + final_options
+
+        def is_valid_dynamic(option):  # pragma: no cover
+            return option in [str(i) for i in range(1, len(choices) + 1)] or option == "."
+
         choice = create_menu(
             f"Select a platform entry for {platform_name}:",
             choices,
-            validate_method=is_valid,
+            validate_method=is_valid_dynamic,
         )
         if choice == ".":
             print("Quitting")

--- a/pepys_import/resolvers/command_line_resolver.py
+++ b/pepys_import/resolvers/command_line_resolver.py
@@ -144,7 +144,7 @@ class CommandLineResolver(DataResolver):
                     f"{platform.name} / {platform.identifier} / {platform.nationality_name}"
                 )
             final_options[1] += f", default name '{platform_name}'"
-        choices = platform_details + final_options
+        choices = final_options + platform_details
 
         def is_valid_dynamic(option):  # pragma: no cover
             return option in [str(i) for i in range(1, len(choices) + 1)] or option == "."
@@ -157,11 +157,7 @@ class CommandLineResolver(DataResolver):
         if choice == ".":
             print("Quitting")
             sys.exit(1)
-        if int(choice) <= len(platform_details):
-            # One of the pre-existing platforms was chosen
-            platform_index = int(choice) - 1
-            return platforms[platform_index]
-        elif choice == str(len(choices) - 1):
+        elif choice == str(1):
             return self.fuzzy_search_platform(
                 data_store,
                 platform_name,
@@ -170,7 +166,7 @@ class CommandLineResolver(DataResolver):
                 privacy,
                 change_id,
             )
-        elif choice == str(len(choices)):
+        elif choice == str(2):
             return self.add_to_platforms(
                 data_store,
                 platform_name,
@@ -179,6 +175,10 @@ class CommandLineResolver(DataResolver):
                 privacy,
                 change_id,
             )
+        elif 3 <= int(choice) <= len(choices):
+            # One of the pre-existing platforms was chosen
+            platform_index = int(choice) - 3
+            return platforms[platform_index]
 
     def resolve_sensor(self, data_store, sensor_name, sensor_type, host_id, privacy, change_id):
         Platform = data_store.db_classes.Platform

--- a/tests/test_command_line_resolver.py
+++ b/tests/test_command_line_resolver.py
@@ -434,7 +434,7 @@ class PlatformTestCase(unittest.TestCase):
     def test_resolve_platform_select_existing_platform(self, resolver_prompt, menu_prompt):
         """Test whether a new platform entity is created or not"""
 
-        menu_prompt.side_effect = ["1"]
+        menu_prompt.side_effect = ["3"]
         with self.store.session_scope():
             privacy = self.store.add_to_privacies("Public", 0, self.change_id)
             platform_type = self.store.add_to_platform_types("Warship", self.change_id)


### PR DESCRIPTION
## 🧰 Issue
Fixes #607 .

## 🤔 Reason: 
Solving the bug.

## 🔨Work carried out:
I changed the validation function for platform resolver. Then, I successfully created a platform using the third option which was not possible before.

- [x] Tests pass

## 🖥️ Screenshot
<img width="413" alt="image" src="https://user-images.githubusercontent.com/41292272/98930888-59107800-24ee-11eb-9ebd-81c264980100.png">

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
