### PR TITLE
Increase benchmark time thresholds

### DIFF
--- a/tests/benchmarks/test_highlighter_benchmark.py
+++ b/tests/benchmarks/test_highlighter_benchmark.py
@@ -134,7 +134,7 @@ def run_highlighter_on_whole_file():
 def test_highlighter_on_whole_file_benchmark(benchmark):
     benchmark(run_highlighter_on_whole_file)
 
-    TIME_THRESHOLD = 7.5
+    TIME_THRESHOLD = 8
 
     if running_on_ci():
         if benchmark.stats.stats.mean > TIME_THRESHOLD:

--- a/tests/benchmarks/test_highlighter_benchmark.py
+++ b/tests/benchmarks/test_highlighter_benchmark.py
@@ -134,7 +134,7 @@ def run_highlighter_on_whole_file():
 def test_highlighter_on_whole_file_benchmark(benchmark):
     benchmark(run_highlighter_on_whole_file)
 
-    TIME_THRESHOLD = 8
+    TIME_THRESHOLD = 9
 
     if running_on_ci():
         if benchmark.stats.stats.mean > TIME_THRESHOLD:

--- a/tests/benchmarks/test_import_benchmark.py
+++ b/tests/benchmarks/test_import_benchmark.py
@@ -51,7 +51,7 @@ def test_single_rep_file_import_long(benchmark):
         rounds=1,
     )
 
-    TIME_THRESHOLD = 60
+    TIME_THRESHOLD = 65
 
     if running_on_ci():
         if benchmark.stats.stats.mean > TIME_THRESHOLD:


### PR DESCRIPTION
## 🚀 Overview: 
Tests were failing intermittently on Github Actions because of variability in the time taken to execute the benchmarking code. This increases the time threshold allowed for a couple of the benchmarks, to give us more flexibility before the test fails. We will still get failures if the time taken for the test increases significantly.

## 🤔 Reason: 
We want reliable tests.

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.