### PR TITLE
Set up automatic releases on Github Actions

### DIFF
--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -2,8 +2,8 @@ name: Create deployment
 on:
   push:
     branches:
-    - master
-  pull_request:
+    - automatic-releases
+  #pull_request:
 
 jobs:
   create-deployment:
@@ -33,10 +33,9 @@ jobs:
 
       - name: Release
         uses: softprops/action-gh-release@v1
-        #if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: Version ${{ steps.get_version.outputs.VERSION }}
           draft: true
-          files: Release.txt
+          files: ./*_pepys-import.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -31,23 +31,12 @@ jobs:
           name: Pepys Deployment
           path: ./*_pepys-import.zip
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        #if: startsWith(github.ref, 'refs/tags/')
+        with:
+          name: Version ${{ steps.get_version.outputs.VERSION }}
+          draft: true
+          files: Release.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Version ${{ github.ref }}
-          draft: false
-          prerelease: true
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./*_pepys-import.zip
-          asset_name: pepys_${{ github.ref }}.zip
-          asset_content_type: application/zip

--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -3,7 +3,10 @@ on:
   push:
     branches:
     - automatic-releases
+    tags:
+      - '*'
   #pull_request:
+
 
 jobs:
   create-deployment:

--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -30,3 +30,24 @@ jobs:
         with:
           name: Pepys Deployment
           path: ./*_pepys-import.zip
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Version ${{ github.ref }}
+          draft: false
+          prerelease: true
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./*_pepys-import.zip
+          asset_name: pepys_${{ github.ref }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       - '*'
-    pull_request:
+  pull_request:
 
 
 jobs:

--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -1,11 +1,9 @@
 name: Create deployment
 on:
   push:
-    branches:
-    - automatic-releases
     tags:
       - '*'
-  #pull_request:
+    pull_request:
 
 
 jobs:
@@ -29,12 +27,13 @@ jobs:
         shell: cmd
         run: cd bin & pepys_import.bat --path ../tests/sample_data/track_files/rep_data/rep_test1.rep --db ":memory:" --resolver default
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
         with:
           name: Pepys Deployment
           path: ./*_pepys-import.zip
 
-      - name: Release
+      - name: Create release (only for tags)
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:


### PR DESCRIPTION
## 🧰 Issue
As requested in a comment on PR #598

## 🚀 Overview: 
Added Github Actions steps to automatically produce a release for tagged commits in the repository.

## 🤔 Reason: 
This means a release is automatically created using a 'known good' VM that is configured for producing releases. It saves Ian from producing releases manually. The release that is created is set in 'draft' mode by default - so it can be checked and brie release notes can be added to the body, before making it public.

Unfortunately the only way to fully test this is to merge it first (I've done tests that show that it should work, but we can't test with a tag on the master branch until this is merged). Therefore, I suggest @IanMayo merges this, and then merges develop to master and creates a test tag on the master branch. This should then create a draft release, which can be deleted afterwards.

## 🔨Work carried out:

- [x] Altered GH Actions configuration
- [x] Tested manually

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
