### PR TITLE
Restrict release creation to just those tags that came from master

### DIFF
--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create release (only for tags)
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/master'
         with:
           draft: true
           files: ./*_pepys-import.zip


### PR DESCRIPTION
## 🚀 Overview: 
This restricts the automatic release creation on Github Actions to just tags that were created on master.

## 🤔 Reason: 
This means a tag on another branch can't accidentally create a release for us.

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
@IanMayo Once you've merged this to master, can you test it still works by creating a tag on master and pushing it, and checking a draft release is created?

