### PR TITLE
Update GH Actions config to post 'waiting' comment then link

### DIFF
--- a/.github/workflows/run_pr_on_binder.yml
+++ b/.github/workflows/run_pr_on_binder.yml
@@ -84,9 +84,5 @@ jobs:
             <!-- GH Actions Binder Comment -->
             :rocket: Interactive demo available via Binder [here](https://mybinder.org/v2/gh/debrief/pepys-import/${{github.head_ref}}?filepath=demos/).
 
-            *Notes:*
-             - The Jupyter notebook browser will open in the `demos` folder. See comments above for which notebook to use,
-               otherwise use the `_Default_Demo.ipynb` notebook.
-             - Binder takes around five minutes to build the repository into an image. If you click this link less than five minutes
-               after a new commit has been pushed, then you will start another build. This won't break anything, but will cause you to
-               wait longer than you needed to as two builds will be running.
+            *Note:* The Jupyter notebook browser will open in the `demos` folder. See comments above for which notebook to use,
+            otherwise use the `_Default_Demo.ipynb` notebook.

--- a/.github/workflows/run_pr_on_binder.yml
+++ b/.github/workflows/run_pr_on_binder.yml
@@ -29,6 +29,10 @@ jobs:
           issue-number: ${{github.event.number}}
           body-includes: <!-- GH Actions Binder Comment -->
 
+      - name: Debug Find Comment
+        shell: bash
+        run: echo ${{ steps.findComment.outputs.comment-id }}
+
       - name: Create comment
         id: createComment
         if: ${{ steps.checkLabel.outputs.hasLabel && (steps.findComment.outputs.comment-id == 0) }}

--- a/.github/workflows/run_pr_on_binder.yml
+++ b/.github/workflows/run_pr_on_binder.yml
@@ -10,18 +10,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: Dreamcodeio/pr-has-label-action@master
+      - name: Check for 'interactive_review' label
+        uses: Dreamcodeio/pr-has-label-action@master
         id: checkLabel
         with:
           label: interactive_review
 
-      - name: Get build finish time
+      - name: Calculate build finish time
         id: buildFinish
         if: ${{ steps.checkLabel.outputs.hasLabel }}
         shell: bash
         run: echo ::set-output name=finish_time::`TZ='Europe/London' date --date 'now + 5 minutes' +%H:%M`
       
-      - name: Find Comment (in case it already exists)
+      - name: Find comment (in case one already exists)
         if: ${{ steps.checkLabel.outputs.hasLabel }}
         uses: peter-evans/find-comment@v1
         id: findComment
@@ -29,11 +30,7 @@ jobs:
           issue-number: ${{github.event.number}}
           body-includes: <!-- GH Actions Binder Comment -->
 
-      - name: Debug Find Comment
-        shell: bash
-        run: echo ${{ steps.findComment.outputs.comment-id }}
-
-      - name: Create comment
+      - name: Create comment (if it doesn't exist)
         id: createComment
         if: ${{ steps.checkLabel.outputs.hasLabel && (steps.findComment.outputs.comment-id == 0) }}
         uses: peter-evans/create-or-update-comment@v1
@@ -41,9 +38,9 @@ jobs:
           issue-number: ${{github.event.number}}
           body: |
             <!-- GH Actions Binder Comment -->
-            Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.
+            Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }} UK time.
 
-      - name: Update comment
+      - name: Update comment (if it already exists)
         if: ${{ steps.checkLabel.outputs.hasLabel && (steps.findComment.outputs.comment-id != 0) }}
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -52,9 +49,10 @@ jobs:
           edit-mode: replace
           body: |
             <!-- GH Actions Binder Comment -->
-            Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.      
+            Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }} UK time.      
 
-      - uses: s-weigand/trigger-mybinder-build@v1
+      - name: Trigger builds on Binder
+        uses: s-weigand/trigger-mybinder-build@v1
         if: ${{ steps.checkLabel.outputs.hasLabel }}
         with:
           target-repo: debrief/pepys-import
@@ -66,8 +64,8 @@ jobs:
         with:
           time: '5m'
 
-      # We can't just use the earlier output from findComment as we may have created a new one
-      - name: Find Comment from earlier
+      # We can't just use the earlier output from findComment as we may have created a new comment
+      - name: Find comment from earlier
         if: ${{ steps.checkLabel.outputs.hasLabel }}
         uses: peter-evans/find-comment@v1
         id: findComment2

--- a/.github/workflows/run_pr_on_binder.yml
+++ b/.github/workflows/run_pr_on_binder.yml
@@ -48,7 +48,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{github.event.number}}
-          comment-id: steps.findComment.outputs.comment-id
+          comment-id: ${{ steps.findComment.outputs.comment-id }}
           edit-mode: replace
           body: |
             <!-- GH Actions Binder Comment -->

--- a/.github/workflows/run_pr_on_binder.yml
+++ b/.github/workflows/run_pr_on_binder.yml
@@ -15,6 +15,35 @@ jobs:
         with:
           label: interactive_review
 
+      - name: Get build finish time
+        id: buildFinish
+        if: ${{ steps.checkLabel.outputs.hasLabel }}
+        shell: bash
+        run: echo ::set-output name=finish_time::`TZ='Europe/London' date --date 'now + 5 minutes' +%H:%M`
+      
+      - name: Find Comment (in case it already exists)
+        if: ${{ steps.checkLabel.outputs.hasLabel }}
+        uses: peter-evans/find-comment@v1
+        id: findComment
+        with:
+          issue-number: ${{github.event.number}}
+          body-includes: <!-- GH Actions Binder Comment --!>
+
+      - name: Create comment
+        if: ${{ steps.checkLabel.outputs.hasLabel && (steps.findComment.outputs.comment-id == 0) }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{github.event.number}}
+          body: Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.
+
+      - name: Update comment
+        if: ${{ steps.checkLabel.outputs.hasLabel && (steps.findComment.outputs.comment-id != 0) }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{github.event.number}}
+          comment-id: steps.findComment.outputs.comment-id
+          body: Building interactive demo on Binder, due to complete at ${{ buildFinish.outputs.finish_time }}.      
+
       - uses: s-weigand/trigger-mybinder-build@v1
         if: ${{ steps.checkLabel.outputs.hasLabel }}
         with:
@@ -27,19 +56,20 @@ jobs:
         with:
           time: '5m'
 
-      - name: Find Comment (in case it already exists)
-        if: ${{ steps.checkLabel.outputs.hasLabel }}
-        uses: peter-evans/find-comment@v1
-        id: findComment
-        with:
-          issue-number: ${{github.event.number}}
-          body-includes: Interactive demo available via Binder
+      # - name: Find Comment (in case it already exists)
+      #   if: ${{ steps.checkLabel.outputs.hasLabel }}
+      #   uses: peter-evans/find-comment@v1
+      #   id: findComment
+      #   with:
+      #     issue-number: ${{github.event.number}}
+      #     body-includes: Interactive demo available via Binder
 
-      - name: Create comment (if it doesn't already exist)
-        if: ${{ steps.checkLabel.outputs.hasLabel && (steps.findComment.outputs.comment-id == 0) }}
+      - name: Update comment with link
+        if: ${{ steps.checkLabel.outputs.hasLabel }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{github.event.number}}
+          comment-id: steps.findComment.outputs.comment-id
           body: |
             :rocket: Interactive demo available via Binder [here](https://mybinder.org/v2/gh/debrief/pepys-import/${{github.head_ref}}?filepath=demos/).
 

--- a/.github/workflows/run_pr_on_binder.yml
+++ b/.github/workflows/run_pr_on_binder.yml
@@ -27,7 +27,7 @@ jobs:
         id: findComment
         with:
           issue-number: ${{github.event.number}}
-          body-includes: <!-- GH Actions Binder Comment --!>
+          body-includes: <!-- GH Actions Binder Comment -->
 
       - name: Create comment
         id: createComment
@@ -36,7 +36,7 @@ jobs:
         with:
           issue-number: ${{github.event.number}}
           body: |
-            <!-- GH Actions Binder Comment --!>
+            <!-- GH Actions Binder Comment -->
             Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.
 
       - name: Update comment
@@ -45,8 +45,9 @@ jobs:
         with:
           issue-number: ${{github.event.number}}
           comment-id: steps.findComment.outputs.comment-id
+          edit-mode: replace
           body: |
-            <!-- GH Actions Binder Comment --!>
+            <!-- GH Actions Binder Comment -->
             Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.      
 
       - uses: s-weigand/trigger-mybinder-build@v1
@@ -61,14 +62,6 @@ jobs:
         with:
           time: '5m'
 
-      # - name: Find Comment (in case it already exists)
-      #   if: ${{ steps.checkLabel.outputs.hasLabel }}
-      #   uses: peter-evans/find-comment@v1
-      #   id: findComment
-      #   with:
-      #     issue-number: ${{github.event.number}}
-      #     body-includes: Interactive demo available via Binder
-
       # We can't just use the earlier output from findComment as we may have created a new one
       - name: Find Comment from earlier
         if: ${{ steps.checkLabel.outputs.hasLabel }}
@@ -76,7 +69,7 @@ jobs:
         id: findComment2
         with:
           issue-number: ${{github.event.number}}
-          body-includes: <!-- GH Actions Binder Comment --!>
+          body-includes: <!-- GH Actions Binder Comment -->
 
       - name: Update comment with link
         if: ${{ steps.checkLabel.outputs.hasLabel }}
@@ -84,8 +77,9 @@ jobs:
         with:
           issue-number: ${{github.event.number}}
           comment-id: ${{ steps.findComment2.outputs.comment-id }}
+          edit-mode: replace
           body: |
-            <!-- GH Actions Binder Comment --!>
+            <!-- GH Actions Binder Comment -->
             :rocket: Interactive demo available via Binder [here](https://mybinder.org/v2/gh/debrief/pepys-import/${{github.head_ref}}?filepath=demos/).
 
             *Notes:*

--- a/.github/workflows/run_pr_on_binder.yml
+++ b/.github/workflows/run_pr_on_binder.yml
@@ -69,7 +69,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{github.event.number}}
-          comment-id: steps.findComment.outputs.comment-id
+          comment-id: ${{ steps.findComment.outputs.comment-id }}
           body: |
             :rocket: Interactive demo available via Binder [here](https://mybinder.org/v2/gh/debrief/pepys-import/${{github.head_ref}}?filepath=demos/).
 

--- a/.github/workflows/run_pr_on_binder.yml
+++ b/.github/workflows/run_pr_on_binder.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           issue-number: ${{github.event.number}}
           comment-id: steps.findComment.outputs.comment-id
-          body: Building interactive demo on Binder, due to complete at ${{ buildFinish.outputs.finish_time }}.      
+          body: Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.      
 
       - uses: s-weigand/trigger-mybinder-build@v1
         if: ${{ steps.checkLabel.outputs.hasLabel }}

--- a/.github/workflows/run_pr_on_binder.yml
+++ b/.github/workflows/run_pr_on_binder.yml
@@ -30,11 +30,14 @@ jobs:
           body-includes: <!-- GH Actions Binder Comment --!>
 
       - name: Create comment
+        id: createComment
         if: ${{ steps.checkLabel.outputs.hasLabel && (steps.findComment.outputs.comment-id == 0) }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{github.event.number}}
-          body: Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.
+          body: |
+            <!-- GH Actions Binder Comment --!>
+            Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.
 
       - name: Update comment
         if: ${{ steps.checkLabel.outputs.hasLabel && (steps.findComment.outputs.comment-id != 0) }}
@@ -42,7 +45,9 @@ jobs:
         with:
           issue-number: ${{github.event.number}}
           comment-id: steps.findComment.outputs.comment-id
-          body: Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.      
+          body: |
+            <!-- GH Actions Binder Comment --!>
+            Building interactive demo on Binder, due to complete at ${{ steps.buildFinish.outputs.finish_time }}.      
 
       - uses: s-weigand/trigger-mybinder-build@v1
         if: ${{ steps.checkLabel.outputs.hasLabel }}
@@ -64,13 +69,23 @@ jobs:
       #     issue-number: ${{github.event.number}}
       #     body-includes: Interactive demo available via Binder
 
+      # We can't just use the earlier output from findComment as we may have created a new one
+      - name: Find Comment from earlier
+        if: ${{ steps.checkLabel.outputs.hasLabel }}
+        uses: peter-evans/find-comment@v1
+        id: findComment2
+        with:
+          issue-number: ${{github.event.number}}
+          body-includes: <!-- GH Actions Binder Comment --!>
+
       - name: Update comment with link
         if: ${{ steps.checkLabel.outputs.hasLabel }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{github.event.number}}
-          comment-id: ${{ steps.findComment.outputs.comment-id }}
+          comment-id: ${{ steps.findComment2.outputs.comment-id }}
           body: |
+            <!-- GH Actions Binder Comment --!>
             :rocket: Interactive demo available via Binder [here](https://mybinder.org/v2/gh/debrief/pepys-import/${{github.head_ref}}?filepath=demos/).
 
             *Notes:*


### PR DESCRIPTION
## 🧰 Issue
N/A (extension to #635)

## 🚀 Overview: 
Updated the Github Actions workflow for interactive reviewing of PRs to post a message with an estimated completion time for the Binder builds, and then update that message with a link to the Binder once it's built.

## 🔗 Link to preview (or screenshot, if relevant)
The relevant comments can be seen on this PR's comment thread - click the 'edited' button to see previous versions of the comment.

## 🤔 Reason: 
This removes the need to warn the user to wait for at least 5 minutes, as the link won't be there until the builds have finished.

## 🔨Work carried out:

- [x] Updated GH Actions config
- [x] Tested manually in each possible situation

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

