### PR TITLE
Fix Linux build on GH Actions

### DIFF
--- a/.github/workflows/test_pepys.yml
+++ b/.github/workflows/test_pepys.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Install apt dependencies
         shell: bash -l {0}
         run: |
+          sudo apt update
           sudo apt install -y postgresql-13-postgis-3 sqlite3 libgdal-dev libproj-dev libproj-dev libsqlite3-dev spatialite-bin libsqlite3-mod-spatialite
 
       - name: Set up Python 3.7


### PR DESCRIPTION
## 🚀 Overview: 
Linux builds on the GH Actions CI were failing due to an apt-get error. This fixes that by calling `apt update` explicitly before doing the install.

## 🤔 Reason: 
It makes the builds work again 😄 

## 🔨Work carried out:

- [x] Updated GH Actions workflow config
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
It seems that Github Actions provides a cached version of the apt-get package list, so that you don't have to do a manual `apt update` before an `apt install`. However, this cached version seems to be out of step with the Postgres/PostGIS apt site - which means apt looks for a package that doesn't exist. Adding an explicit `apt update` step before `apt install` fixes this, and makes it more robust for the future, at the expense of an extra 30s of run time for the build.

