### PR TITLE
Fix enhanced validator to not compare bearing/heading if ship stopped

### DIFF
--- a/pepys_import/core/validators/enhanced_validator.py
+++ b/pepys_import/core/validators/enhanced_validator.py
@@ -62,9 +62,12 @@ class EnhancedValidator:
             prev_time = prev_object.time
 
             if location and prev_location:
-                self.course_heading_loose_match_with_location(
-                    location, prev_location, heading, course, errors, error_type
-                )
+                # Only calculate bearing from the locations and compare to heading
+                # if the vessel has actually moved between the prev_location and the new location
+                if location != prev_location:
+                    self.course_heading_loose_match_with_location(
+                        location, prev_location, heading, course, errors, error_type
+                    )
                 calculated_time = self.calculate_time(time, prev_time)
                 if calculated_time != 0:
                     self.speed_loose_match_with_location(


### PR DESCRIPTION
## 🧰 Issue
#583 

## 🚀 Overview: 
The enhanced validator compares the heading specified in the input file against a bearing calculated from the current location and the previous location. If they are significantly different, it raises an error. This PR changes the code so that the comparison doesn't happen if the vessel is stopped (ie. the previous location and the current location are the same). When comparisons were happening in this situation, they were showing a bearing of 0, which didn't match the heading - and so was incorrectly raising an error.

## 🤔 Reason: 
Fixes a bug.

## 🔨Work carried out:
- [x] Fix bug
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->

