### PR TITLE
Remove ability to add reference table entries during import

### DIFF
--- a/pepys_import/resolvers/command_line_resolver.py
+++ b/pepys_import/resolvers/command_line_resolver.py
@@ -285,6 +285,7 @@ class CommandLineResolver(DataResolver):
             title,
             options,
             validate_method=is_valid_dynamic,
+            cancel=f"import (Please cancel import & contact an expert Pepys user if you require a new {text_name} to be added to Pepys)",
         )
         if choice == ".":
             print("-" * 61, "\nReturning to the previous menu\n")

--- a/pepys_import/resolvers/command_line_resolver.py
+++ b/pepys_import/resolvers/command_line_resolver.py
@@ -251,7 +251,7 @@ class CommandLineResolver(DataResolver):
         """
         if text_name is None:
             text_name = field_name.replace("_", "-")
-        options = [f"Search an existing {text_name}", f"Add a new {text_name}"]
+        options = [f"Search an existing {text_name}"]
         title = f"Ok, please provide {text_name} for new {data_type}: "
         current_values = ""
         if db_class.__tablename__ == constants.NATIONALITY:
@@ -263,7 +263,7 @@ class CommandLineResolver(DataResolver):
             )
         elif db_class.__tablename__ == constants.PRIVACY:
             all_values = data_store.session.query(db_class).order_by(db_class.level).all()
-            objects = all_values[:7]
+            objects = all_values[:8]
             current_values = "\nCurrent Privacies in the Database\n"
             headers = ["name", "level"]
             current_values += tabulate(
@@ -274,16 +274,8 @@ class CommandLineResolver(DataResolver):
             )
             current_values += "\n"
         else:
-            objects = data_store.session.query(db_class).limit(7).all()
+            objects = data_store.session.query(db_class).limit(8).all()
         objects_dict = {obj.name: obj for obj in objects}
-        # CamelCase table names should be split into words, separated by "-" and converted to
-        # lowercase for matching with DataStore add methods (i.e. PlatformTypes -> platform_types)
-        plural_field = (
-            re.sub("([A-Z][a-z]+)", r" \1", re.sub("([A-Z]+)", r"\1", db_class.__tablename__))
-            .strip()
-            .lower()
-            .replace(" ", "_")
-        )
         options.extend(objects_dict)
 
         def is_valid_dynamic(option):  # pragma: no cover
@@ -307,36 +299,7 @@ class CommandLineResolver(DataResolver):
                 )
             else:
                 return result
-        elif choice == str(2):
-            print(current_values)
-            while True:
-                new_object = prompt(
-                    format_command(f"Please type name of new {text_name}: ")
-                ).strip()
-                # If not too long for the field
-                if len(new_object) <= 150:
-                    break
-                else:
-                    print("Name too long, please enter a name less than 150 characters long")
-            search_method = getattr(data_store, f"search_{field_name}")
-            obj = search_method(new_object)
-            if obj:
-                return obj
-            elif new_object:
-                add_method = getattr(data_store, f"add_to_{plural_field}")
-                if plural_field == "privacies":
-                    level = prompt(
-                        format_command(f"Please type level of new {text_name}: "),
-                        validator=numeric_validator,
-                    )
-                    return add_method(new_object, level, change_id)
-                return add_method(new_object, change_id)
-            else:
-                print("You haven't entered an input!")
-                return self.resolve_reference(
-                    data_store, change_id, data_type, db_class, field_name, text_name
-                )
-        elif 3 <= int(choice) <= len(options):
+        elif 2 <= int(choice) <= len(options):
             selected_object = objects_dict[options[int(choice) - 1]]
             if selected_object:
                 return selected_object

--- a/pepys_import/resolvers/command_line_resolver.py
+++ b/pepys_import/resolvers/command_line_resolver.py
@@ -271,7 +271,7 @@ class CommandLineResolver(DataResolver):
             title,
             options,
             validate_method=is_valid_dynamic,
-            cancel=f"import (Please cancel import & contact an expert Pepys user if you require a new {text_name} to be added to Pepys)",
+            cancel=f"import (Please contact an expert user if you need a new {text_name} to be added)",
         )
         if choice == ".":
             print("-" * 61, "\nReturning to the previous menu\n")

--- a/tests/test_command_line_resolver.py
+++ b/tests/test_command_line_resolver.py
@@ -116,8 +116,8 @@ class ReferenceDataTestCase(unittest.TestCase):
     def test_fuzzy_search_select_privacy_directly(self, menu_prompt):
         """Test whether recursive call works for privacy"""
 
-        # Select "3-Public"
-        menu_prompt.side_effect = ["3"]
+        # Select "2-Public"
+        menu_prompt.side_effect = ["2"]
         with self.store.session_scope():
             self.store.add_to_privacies("Public", 0, self.change_id)
             self.store.add_to_privacies("Public Sensitive", 0, self.change_id)
@@ -169,27 +169,6 @@ class ReferenceDataTestCase(unittest.TestCase):
             assert platform_type.name == "TYPE-TEST"
 
     @patch("pepys_import.resolvers.command_line_resolver.create_menu")
-    @patch("pepys_import.resolvers.command_line_resolver.prompt")
-    def test_fuzzy_search_select_existing_platform_type_without_search(
-        self, resolver_prompt, menu_prompt
-    ):
-        """Test whether a new PlatformType entity created or not"""
-
-        # Select "Add a new platform-type"->Type "TYPE-TEST"
-        menu_prompt.side_effect = ["2"]
-        resolver_prompt.side_effect = ["TYPE-TEST"]
-        with self.store.session_scope():
-            self.store.add_to_privacies("TYPE-TEST", 0, self.change_id)
-            platform_type = self.resolver.resolve_reference(
-                self.store,
-                self.change_id,
-                "",
-                self.store.db_classes.PlatformType,
-                "platform_type",
-            )
-            self.assertEqual(platform_type.name, "TYPE-TEST")
-
-    @patch("pepys_import.resolvers.command_line_resolver.create_menu")
     def test_fuzzy_search_recursive_platform_type(self, menu_prompt):
         """Test whether recursive call works for platform_type"""
 
@@ -212,8 +191,8 @@ class ReferenceDataTestCase(unittest.TestCase):
     def test_fuzzy_search_select_platform_type_directly(self, menu_prompt):
         """Test whether recursive call works for platform_type"""
 
-        # Select "3-TYPE-1"
-        menu_prompt.side_effect = ["3"]
+        # Select "2-TYPE-1"
+        menu_prompt.side_effect = ["2"]
         with self.store.session_scope():
             self.store.add_to_platform_types("TYPE-1", self.change_id)
             self.store.add_to_platform_types("TYPE-2", self.change_id)
@@ -229,7 +208,7 @@ class ReferenceDataTestCase(unittest.TestCase):
     @patch("pepys_import.resolvers.command_line_resolver.create_menu")
     def test_resolver_reference_select_nationality_directly(self, menu_prompt):
         # Select "3-UK"
-        menu_prompt.side_effect = ["3", "4", "5", "6"]
+        menu_prompt.side_effect = ["2", "3", "4", "5"]
         with self.store.session_scope():
             self.store.add_to_nationalities("UK", self.change_id, priority=1)
             self.store.add_to_nationalities("FR", self.change_id, priority=2)
@@ -317,24 +296,6 @@ class ReferenceDataTestCase(unittest.TestCase):
             assert privacy is None
         output = temp_output.getvalue()
         assert "Returning to the previous menu" in output
-
-    @patch("pepys_import.resolvers.command_line_resolver.create_menu")
-    @patch("pepys_import.resolvers.command_line_resolver.prompt")
-    def test_resolve_reference_empty_input(self, resolver_prompt, menu_prompt):
-        resolver_prompt.side_effect = [""]
-        menu_prompt.side_effect = ["2", "."]
-        temp_output = StringIO()
-        with self.store.session_scope(), redirect_stdout(temp_output):
-            self.resolver.resolve_reference(
-                self.store,
-                self.change_id,
-                "",
-                self.store.db_classes.Privacy,
-                "privacy",
-                "classification",
-            )
-        output = temp_output.getvalue()
-        assert "You haven't entered an input!" in output
 
 
 class PlatformTestCase(unittest.TestCase):
@@ -501,51 +462,6 @@ class PlatformTestCase(unittest.TestCase):
             self.store.add_to_privacies("Public", 0, self.change_id)
             self.store.add_to_platform_types("Warship", self.change_id)
             self.store.add_to_nationalities("UK", self.change_id)
-            (
-                platform_name,
-                trigraph,
-                quadgraph,
-                identifier,
-                platform_type,
-                nationality,
-                privacy,
-            ) = self.resolver.resolve_platform(
-                data_store=self.store,
-                platform_name="TEST",
-                platform_type=None,
-                nationality=None,
-                privacy=None,
-                change_id=self.change_id,
-            )
-            self.assertEqual(platform_name, "TEST")
-            self.assertEqual(trigraph, "TST")
-            self.assertEqual(quadgraph, "TEST")
-            self.assertEqual(identifier, "123")
-            self.assertEqual(platform_type.name, "Warship")
-            self.assertEqual(nationality.name, "UK")
-            self.assertEqual(privacy.name, "Public")
-
-    @patch("pepys_import.resolvers.command_line_resolver.create_menu")
-    @patch("pepys_import.resolvers.command_line_resolver.prompt")
-    def test_resolver_platform_with_new_values(self, resolver_prompt, menu_prompt):
-        """Test whether new platform type, nationality and privacy entities are created for Platform
-        or not"""
-
-        # Select "Add a new platform"->Type name/trigraph/quadgraph/identifier->Select
-        # "Add a new nationality"->Select "UK"->Select "Add a new platform type"->Select "Warship
-        # ->Select "Add a new classification"->Select "Public"->Select "0"->Select "Yes"
-        menu_prompt.side_effect = ["2", "2", "2", "2", "1"]
-        resolver_prompt.side_effect = [
-            "TEST",
-            "123",
-            "TST",
-            "TEST",
-            "UK",
-            "Warship",
-            "Public",
-            "0",
-        ]
-        with self.store.session_scope():
             (
                 platform_name,
                 trigraph,
@@ -1342,61 +1258,16 @@ class CancellingAndReturnPreviousMenuTestCase(unittest.TestCase):
         menu_prompt.side_effect = [
             ".",
             ".",
-            "2",
-            ".",
-            ".",
-            "2",
-            "2",
-            ".",
-            ".",
-            "2",
-            "2",
-            "2",
-            ".",
-            ".",
         ]
         resolver_prompt.side_effect = [
             "TEST",
             "123",
             "TST",
             "TEST",
-            "TEST",
-            "123",
-            "TST",
-            "TEST",
-            "UK",
-            "TEST",
-            "123",
-            "TST",
-            "TEST",
-            "UK",
-            "TYPE-1",
-            "TEST",
-            "123",
-            "TST",
-            "TEST",
-            "UK",
-            "TYPE-1",
-            "Public",
-            "0",
         ]
         with self.store.session_scope():
             # Type name/trigraph/quadgraph/identifier->Select "Cancel nationality search"->
             # Select "Cancel import"
-            with self.assertRaises(SystemExit):
-                self.resolver.add_to_platforms(self.store, "PLATFORM-1", "", "", "", self.change_id)
-            # Type name/trigraph/quadgraph/identifier->Select "Add new nationality"->Type "UK"->
-            # Select "Cancel platform type search"->Select "Cancel import"
-            with self.assertRaises(SystemExit):
-                self.resolver.add_to_platforms(self.store, "PLATFORM-1", "", "", "", self.change_id)
-            # Type name/trigraph/quadgraph/identifier->Select "Add new nationality"->Type "UK"->
-            # Select "Add a new platform type"->Type "TYPE-1"->Select "Cancel classification search"->
-            # Select "Cancel import"
-            with self.assertRaises(SystemExit):
-                self.resolver.add_to_platforms(self.store, "PLATFORM-1", "", "", "", self.change_id)
-            # Type name/trigraph/quadgraph/identification->Select "Add new nationality"->Type "UK"->
-            # Select "Add a new platform type"->Select "Add new classification"->Type "Public"->Type
-            # "0"->Select "Cancel import"->Select "Cancel import"
             with self.assertRaises(SystemExit):
                 self.resolver.add_to_platforms(self.store, "PLATFORM-1", "", "", "", self.change_id)
 

--- a/tests/test_import_cli_end_to_end.py
+++ b/tests/test_import_cli_end_to_end.py
@@ -94,11 +94,11 @@ def test_gpx_1_0_import(prompt, menu_prompt, processor_prompt):
 
     **Note:** This will fail if the CLI interface changes at all!"""
     menu_prompt.side_effect = [
-        "5",  # Private
+        "4",  # Private
         "1",  # Yes, create
         "2",  # Add new platform
-        "6",  # Germany
-        "6",  # Ferry
+        "5",  # Germany
+        "5",  # Ferry
         "5",  # Private
         "1",  # Yes, create
         "2",  # Add new sensor

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -725,26 +725,26 @@ class TestImportWithDuplicatePlatformNames(unittest.TestCase):
         ]
 
         menu_prompt.side_effect = [
-            "3",
-            "1",
-            "2",
-            "3",
-            "3",
-            "3",
-            "1",
-            "2",
-            "3",
-            "3",
-            "1",
-            "2",
-            "5",
-            "3",
-            "3",
-            "1",
-            "2",
-            "3",
-            "3",
-            "1",
+            "2",  # Public
+            "1",  # Yes, create
+            "2",  # Add new platform
+            "2",  # UK
+            "2",  # PLATFORM-TYPE-1
+            "2",  # Public
+            "1",  # Yes, create
+            "2",  # Add new sensor
+            "2",  # GPS
+            "2",  # Public
+            "1",  # Yes, create
+            "2",  # Add new platform
+            "4",  # France
+            "2",  # PLATFORM-TYPE-1
+            "2",  # Public
+            "1",  # Yes, create
+            "2",  # Add new sensor
+            "2",  # GPS
+            "2",  # Public
+            "1",  # Yes, create
         ]
         file_processor_prompt.side_effect = [
             "2",  # Import metadata and measurement


### PR DESCRIPTION
## 🧰 Issue
#613 

## 🚀 Overview: 
Removed the ability to add reference table entries during import.

**Warning:** We are changing entries that may have muscle memory for the users. For example, due to the 'shuffling up', the UK nationality is now option `2` not option `3`. We should warn the users about this.

## 🔗 Link to preview (or screenshot, if relevant)
<img width="347" alt="Screen Shot 2020-11-30 at 11 16 32" src="https://user-images.githubusercontent.com/296686/100603815-8ab27d00-32fd-11eb-8e74-8d8d2e6967bf.png">

## 🤔 Reason: 
Stops users accidentally adding invalid reference entries.

## 🔨Work carried out:
 - [x] Remove the option for adding reference entry
 - [x] 'Shuffle up' all the option numbers, to fill in the gap
 - [x] Increase the number of options displayed by 1, as we now have space
 - [x] Fix tests, and deleting a number of tests no longer needed
 - [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

