### PR TITLE
Use white background for Binder xterm

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,5 +1,5 @@
 # Post Build script file for Binder - this is nothing to do with building a standard deployment
 # for Pepys
 conda install -y -c conda-forge libspatialite
-pip install git+git://github.com/robintw/notebook_xterm.git#egg=notebook_xterm
+pip install git+git://github.com/robintw/notebook_xterm.git@white-background#egg=notebook_xterm
 echo "PS1='$ '" >>  ~/.bashrc


### PR DESCRIPTION
**Note:** The white background is implemented in the notebook_xterm library, so this PR just changes the `postBuild` script to install from the `white-background` branch in our fork of `notebook_xterm`. If we decide we need to be able to switch background colours easily (which I think is unlikely), then I can make it easier to do.

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `closes #1`)] -->
Supports #646

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->

## 🔗 Link to preview (or screenshot, if relevant)
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->

## 🔨Work carried out:

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->

- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->

## Confirmations

- [ ] I have chosen reviewers for my PR.
- [ ] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [ ] I have extended/updated the documentation in `\docs` folder
- [ ] I have completed the mandatory sections of this document.
- [ ] I have deleted any unused sections.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->

