### PR TITLE
Change message about resetting db to show default option

### DIFF
--- a/pepys_admin/cli.py
+++ b/pepys_admin/cli.py
@@ -102,7 +102,7 @@ def run_shell(path, training=False, data_store=None, db=None, viewer=False):
         pass
 
     if training:
-        answer = prompt(format_command("Would you like to reset the training database? (y/n) "))
+        answer = prompt(format_command("Would you like to reset the training database? (y/N) "))
         if answer.upper() == "Y":
             if os.path.exists(config.DB_NAME):
                 os.remove(config.DB_NAME)

--- a/pepys_import/cli.py
+++ b/pepys_import/cli.py
@@ -141,7 +141,7 @@ def process(
         pass
 
     if training:
-        answer = prompt(format_command("Would you like to reset the training database? (y/n) "))
+        answer = prompt(format_command("Would you like to reset the training database? (y/N) "))
         if answer.upper() == "Y":
             if os.path.exists(config.DB_NAME):
                 os.remove(config.DB_NAME)
@@ -159,7 +159,7 @@ def set_up_training_mode():
 
     if os.path.exists(db_path):
         # Training db already exists, ask if we want to clear it
-        answer = prompt(format_command("Would you like to reset the training database? (y/n) "))
+        answer = prompt(format_command("Would you like to reset the training database? (y/N) "))
         if answer.upper() == "Y":
             os.remove(db_path)
 


### PR DESCRIPTION
## 🧰 Issue
Fixes #671 

## 🚀 Overview: 
Altered the message asking the user whether they want to clear their training database to read:

`Would you like to reset the training database? (y/N)`

with the default option (N) shown in capitals.

## 🤔 Reason: 
Clearer UI. Shows what happens if you just press Enter.

## 🔨Work carried out:

- [x] Altered prompt
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
