### PR TITLE
Fix platform summary

### DIFF
--- a/pepys_import/resolvers/command_line_resolver.py
+++ b/pepys_import/resolvers/command_line_resolver.py
@@ -747,7 +747,7 @@ class CommandLineResolver(DataResolver):
             print(f"Quadgraph: {quadgraph}")
             print(f"Identifier: {identifier}")
             print(f"Nationality: {chosen_nationality.name}")
-            print(f"Class: {chosen_platform_type.name}")
+            print(f"Platform type: {chosen_platform_type.name}")
             print(f"Classification: {chosen_privacy.name}")
 
             choice = create_menu(


### PR DESCRIPTION
## 🧰 Issue
Fixes #676.

## 🚀 Overview: 
Replaced `Class:` in the platform summary output with `Platform type:` to be consistent.

## 🤔 Reason: 
Consistency with the rest of the UI

## 🔨Work carried out:

- [x] Changed output string
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
