### PR TITLE
Improve Run SQL mode

### DIFF
--- a/pepys_admin/view_data_cli.py
+++ b/pepys_admin/view_data_cli.py
@@ -214,7 +214,7 @@ class ViewDataShell(BaseShell):
             print("Please use with care, in admin mode these queries can alter data.")
             print("")
             print("Example SQLite query: SELECT * FROM Platforms;")
-            print('Example Postgres query: SELECT * from "pepys"."Platforms";')
+            print('Example Postgres query: SELECT * from pepys."Platforms";')
             print("")
             query = prompt(
                 "> ", multiline=True, bottom_toolbar=bottom_toolbar, lexer=PygmentsLexer(SqlLexer)

--- a/pepys_admin/view_data_cli.py
+++ b/pepys_admin/view_data_cli.py
@@ -186,6 +186,14 @@ class ViewDataShell(BaseShell):
     def _get_sql_results(self):
         """Asks user to enter a query, then runs it on the database.
         If there isn't any error, returns query and the results."""
+        print(
+            "This feature of Pepys allows you to run arbitrary SQL queries against the Pepys database."
+        )
+        print("Please use with care, in admin mode these queries can alter data.")
+        print("")
+        print("Example SQLite query: SELECT * FROM Platforms;")
+        print('Example Postgres query: SELECT * from "pepys"."Platforms";')
+        print("")
         query = prompt(
             "> ", multiline=True, bottom_toolbar=bottom_toolbar, lexer=PygmentsLexer(SqlLexer)
         )

--- a/pepys_admin/view_data_cli.py
+++ b/pepys_admin/view_data_cli.py
@@ -188,13 +188,17 @@ class ViewDataShell(BaseShell):
 
         split_by_whitespace = stripped.split()
 
-        # If it doesn't start with SELECT then it is not acceptable
-        if split_by_whitespace[0].upper() != "SELECT":
-            return False
+        if len(split_by_whitespace) > 0:
+            # If it doesn't start with SELECT then it is not acceptable
+            if split_by_whitespace[0].upper() != "SELECT":
+                return False
 
         split_by_semicolon = stripped.split(";")
         # If there is anything except whitespace after a ; then it is not acceptable
-        if len(split_by_semicolon) > 2 or split_by_semicolon[1].strip() != "":
+        if len(split_by_semicolon) > 2:
+            return False
+
+        if len(split_by_semicolon) == 2 and split_by_semicolon[1].strip() != "":
             return False
 
         # If we've got here then we're ok

--- a/tests/test_view_data_cli.py
+++ b/tests/test_view_data_cli.py
@@ -367,5 +367,30 @@ class ViewDataCLIPostgresTestCase(unittest.TestCase):
         assert self.shell.intro in output
 
 
+def test_check_query_only_select():
+    store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+    store.initialise()
+    shell = ViewDataShell(store)
+
+    assert shell._check_query_only_select("SELECT * FROM Platforms;")
+    assert shell._check_query_only_select("SELECT    blah from Sensors WHERE sensor_id = 2 ;")
+    assert shell._check_query_only_select("SELECT    blah from Sensors WHERE sensor_id = 2 ;   ")
+    assert shell._check_query_only_select("SELECT    blah from Sensors WHERE sensor_id = 2 ;   ")
+    assert shell._check_query_only_select(
+        "\n  SELECT    blah from Sensors WHERE sensor_id = 2 ;   "
+    )
+
+    assert not shell._check_query_only_select(
+        "SELECT    blah from Sensors WHERE sensor_id = 2 ;  INSERT INTO Platforms Blah"
+    )
+    assert not shell._check_query_only_select(
+        "SELECT blah from Sensors WHERE sensor_id = 2 ;DELETE FROM Platforms WHERE True; "
+    )
+    assert not shell._check_query_only_select("DELETE FROM Platforms WHERE True; ")
+    assert not shell._check_query_only_select(
+        "SELECT blah from Sensors WHERE sensor_id = 2 ; SELECT * FROM Users;"
+    )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 🧰 Issue
Fixes #681
Fixes #679 

## 🚀 Overview: 
Improves the Run SQL option in Pepys Admin/Viewer by:

- Adding guidance text, giving examples of queries
- Only allowing SELECT queries if you're in Pepys Viewer

## 🔗 Link to preview (or screenshot, if relevant)
Example showing guidance text:
![image](https://user-images.githubusercontent.com/296686/101344494-792d2000-387d-11eb-85e0-3b9593cc4f67.png)

Example showing what happens if you run a non-SELECT query in Pepys Viewer
![image](https://user-images.githubusercontent.com/296686/101344530-864a0f00-387d-11eb-8bee-95af849e5a52.png)

## 🤔 Reason: 
- Provides more guidance to the user
- Stops Pepys Viewer users from accidentally changing entries in the database

## 🔨Work carried out:
- [x] Added guidance text
- [x] Added function to check whether a SQL query is just a SELECT query or not
- [x] Added while loop to keep checking if SQL query is valid or not
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
