### PR TITLE
Don't give the option to search for sensors if none exist on the platform

### DIFF
--- a/pepys_import/resolvers/command_line_resolver.py
+++ b/pepys_import/resolvers/command_line_resolver.py
@@ -198,18 +198,24 @@ class CommandLineResolver(DataResolver):
             print("Quitting")
             sys.exit(1)
 
-        options = [
-            f"Search for existing sensor on platform '{host_platform.name}'",
-            "Add a new sensor",
-        ]
         objects = (
             data_store.session.query(data_store.db_classes.Sensor)
             .filter(data_store.db_classes.Sensor.host == host_id)
             .all()
         )
-        objects_dict = {obj.name: obj for obj in objects}
-        if len(objects_dict) <= 7:
-            options.extend(objects_dict)
+        if len(objects) == 0:
+            # No sensors for this platform, so no point asking to search
+            options = ["Add a new sensor"]
+        else:
+            options = [
+                f"Search for existing sensor on platform '{host_platform.name}'",
+                "Add a new sensor",
+            ]
+
+            objects_dict = {obj.name: obj for obj in objects}
+            if len(objects_dict) <= 7:
+                options.extend(objects_dict)
+
         if sensor_name:
             prompt = f"Sensor '{sensor_name}' on platform '{host_platform.name}' not found. Do you wish to: "
         else:


### PR DESCRIPTION
## 🧰 Issue
Fixes #689.

## 🚀 Overview: 
Removed the option to search for a sensor if no sensors are defined on that platform.

## 🔗 Link to preview (or screenshot, if relevant)
![image](https://user-images.githubusercontent.com/296686/101612535-a8b96500-3a02-11eb-9f7b-e21b7a52e603.png)

## 🤔 Reason: 
It doesn't give the user an option that will never work - if there are no sensors defined for the platform then there is no point searching for them.

## 🔨Work carried out:

- [x] Altered list of options depending on number of sensors found
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.