### PR TITLE
Update install script to copy tutorial data to user's home folder

### DIFF
--- a/bin/install_pepys.ps1
+++ b/bin/install_pepys.ps1
@@ -143,3 +143,15 @@ catch {
     Write-Output "ERROR: Could not create file assocations"
     Exit 1
 }
+
+
+# Copy tutorial files into folder in user's home directory
+try {
+    New-Item -Path $env:USERPROFILE -Name "Pepys_Training_Data" -ItemType "directory" -Force
+    Copy-Item -Path "..\tutorial" -Destination "$env:USERPROFILE\Pepys_Training_Data" -Recurse -Force
+}
+catch {
+    Write-Output $_
+    Write-Output "ERROR: Could not copy tutorial data to home folder"
+    Exit 1
+}


### PR DESCRIPTION
## 🧰 Issue
Fixes #697 

## 🚀 Overview: 
Added a section to the install script to copy the tutorial folder from the Pepys folder into the `Pepys_Training_Data` folder in the user's home folder. This is the same folder that will be used for the training database too, keeping it all together in a sensible hierarchy (see screenshot below).

## 🔗 Link to preview (or screenshot, if relevant)
Folder structure on Windows:
![image](https://user-images.githubusercontent.com/296686/101666628-5bf77d80-3a46-11eb-8a22-118a10699253.png)
(inside the `tutorial` folder is all the content from the `tutorial` folder within Pepys - including the `data` folder.

## 🤔 Reason: 
Means that users have their own copies of the tutorial data, so when they alter it, it isn't altered for everyone else too.

## 🔨Work carried out:

- [x] Updated install_pepys.ps1 file
- [x] Tested manually on Windows

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.