### PR TITLE
Upgrade to Python 3.8

### DIFF
--- a/.github/workflows/test_pepys.yml
+++ b/.github/workflows/test_pepys.yml
@@ -19,10 +19,10 @@ jobs:
           sudo apt update
           sudo apt install -y postgresql-13-postgis-3 sqlite3 libgdal-dev libproj-dev libproj-dev libsqlite3-dev spatialite-bin libsqlite3-mod-spatialite
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
   
       - name: Install pip dependencies
         shell: bash -l {0}
@@ -68,10 +68,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       # - name: Install Postgres 12
       #   uses: crazy-max/ghaction-chocolatey@v1

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -2,7 +2,7 @@ Write-Output "INFO: Starting to create Pepys deployment"
 
 # Download embedded Python distribution
 try {
-    $url = 'https://www.python.org/ftp/python/3.7.6/python-3.7.6-embed-amd64.zip'
+    $url = 'https://www.python.org/ftp/python/3.8.6/python-3.8.6-embed-amd64.zip'
     (New-Object System.Net.WebClient).DownloadFile($url,  "$PWD\python.zip")
 }
 catch {
@@ -130,8 +130,8 @@ try {
     # the directory above the python folder (with pepys-import in it). This creates a ._pth file which
     # Python uses as it's *only* source for generating sys.path (ie. it does NOT take into account
     # environment variables such as PYTHONPATH)
-    Set-Content -Encoding ascii .\python\python37._pth @"
-python37.zip
+    Set-Content -Encoding ascii .\python\python38._pth @"
+python38.zip
 .
 Lib\site-packages
 ..

--- a/tests/test_data_store_clear_db.py
+++ b/tests/test_data_store_clear_db.py
@@ -1,4 +1,3 @@
-import platform
 import unittest
 from unittest import TestCase
 
@@ -176,15 +175,11 @@ class DataStoreClearSchemaSpatiaLiteTestCase(TestCase):
         inspector = inspect(data_store_sqlite.engine)
         table_names = inspector.get_table_names()
 
-        SYSTEM = platform.system()
-
-        if SYSTEM == "Windows":
-            correct_n_tables = 38
-        else:
-            correct_n_tables = 36
-
-        # Only the spatial tables (36, or 38 on Windows) must be created. A few of them tested
-        self.assertEqual(len(table_names), correct_n_tables)
+        # Only the spatial tables should be created. The number of these varies depending on the version
+        # of spatialite: either 38 for the later version or 36 for the previous version
+        # On Windows we only support the pre-release version, so we get 38, but this can also happen on
+        # other systems depending on configuration
+        assert len(table_names) == 38 or len(table_names) == 36
 
 
 if __name__ == "__main__":

--- a/tests/test_data_store_initialise.py
+++ b/tests/test_data_store_initialise.py
@@ -1,4 +1,3 @@
-import platform
 import unittest
 from unittest import TestCase
 
@@ -132,15 +131,13 @@ class DataStoreInitialiseSpatiaLiteTestCase(TestCase):
         inspector = inspect(data_store_sqlite.engine)
         table_names = inspector.get_table_names()
 
-        system = platform.system()
+        # The number of spatial tables varies depending on the version of
+        # of spatialite: either 38 for the later version or 36 for the previous version. In total,
+        # including our normal tables, this leads to either 74 or 72 tables.
+        # On Windows we only support the pre-release version of spatialite, so we get 74, but this can also happen on
+        # other systems depending on configuration
+        assert len(table_names) == 74 or len(table_names) == 72
 
-        if system == "Windows":
-            correct_n_tables = 74
-        else:
-            correct_n_tables = 72
-
-        # 37 tables + 36 spatial tables + 1 alembic_version table must be created. A few of them tested
-        self.assertEqual(len(table_names), correct_n_tables)
         self.assertIn("Platforms", table_names)
         self.assertIn("States", table_names)
         self.assertIn("Datafiles", table_names)


### PR DESCRIPTION
## 🧰 Issue
In support of #647, as we need some Python 3.8 features for that to work

## 🚀 Overview: 
Upgraded to Python 3.8, by updating the CI and deployment scripts, and testing fully on Python 3.8 on Windows and OS X. A couple of tests have been updated to be a bit more flexible on numbers of tables being created to take into account different versions of spatialite.

## 🤔 Reason: 
- Allows use of some new ElementTree features in Python 3.8 for the XML parsing/highlighting. The key new feature is:

>The `.find*()` methods in the xml.etree.ElementTree module support wildcard searches like `{*}tag` which ignores the namespace and `{namespace}*` which returns all tags in the given namespace. (Contributed by Stefan Behnel in bpo-28238.)

- Keeps us up-to-date with Python: currently there are only security updates for Python 3.7, there will be no bugfixes to this version 

## 🔨Work carried out:

- [x] Tested on Windows and OS X with Python 3.8
- [x] Updated CI configuration for tests
- [x] Updated deployment script (which is also run on CI for making deployments) to download Python 3.8
- [x] Updated a couple of tests
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
**Important:** I would strongly suggest that all developers @BarisSari @IanMayo upgrade to using Python 3.8 once this is merged, so we're all on the same version.

Also useful to know, is that when doing debug print statements on Python 3.8 you can use a f-string like `f'{var=}'` to print out a nice representation of the variable with its name. For example:

```
>>> user = 'eric_idle'
>>> member_since = date(1975, 7, 31)
>>> f'{user=} {member_since=}'
"user='eric_idle' member_since=datetime.date(1975, 7, 31)"
```