### PR TITLE
Update deployment CI workflow to give full name to release

### DIFF
--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -33,11 +33,16 @@ jobs:
           name: Pepys Deployment
           path: ./*_pepys-import.zip
 
+      - name: Calculate release name
+        id: get_name
+        run: echo ::set-output name=release_name::`date +"%Y%m%d"` - Version ${GITHUB_REF#refs/tags/}
+
       - name: Create release (only for tags)
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/master'
         with:
           draft: true
           files: ./*_pepys-import.zip
+          name: ${{ steps.get_name.outputs.release_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🧰 Issue
Fixes #712 

## 🚀 Overview: 
Updates the CI release workflow to give a full name to the release. The name takes the format `YYYYMMDD - Version $version`

## 🤔 Reason: 
Removes an extra manual step when creating a release.

## 🔨Work carried out:

- [x] Updated GH Actions workflow configuration

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
@IanMayo The only way to properly test this is to merge this PR and then create a new tag on `master` and see what the name of the release is. I _think_ it should work, and I've tested parts of it locally, but it would be good to test it properly. Let me know if there are any problems and I can do another PR.

