### PR TITLE
Improve XML parser source line calculation

### DIFF
--- a/importers/gpx_importer.py
+++ b/importers/gpx_importer.py
@@ -79,7 +79,7 @@ class GPXImporter(Importer):
                 if timestamp_str is None:
                     self.errors.append(
                         {
-                            self.error_type: f"Line {tpt.get_sourceline()} "
+                            self.error_type: f"Line {tpt.sourceline} "
                             "Error: <trkpt> element must have child <time> element"
                         }
                     )
@@ -89,7 +89,7 @@ class GPXImporter(Importer):
                 if not timestamp:
                     self.errors.append(
                         {
-                            self.error_type: f"Line {timestamp_el.get_sourceline()}. "
+                            self.error_type: f"Line {timestamp_el.sourceline}. "
                             f"Error: Invalid timestamp {timestamp_str}"
                         }
                     )

--- a/pepys_import/file/highlighter/xml_parser.py
+++ b/pepys_import/file/highlighter/xml_parser.py
@@ -43,7 +43,9 @@ class MyElement(Element):
     to character offsets first.
     """
 
-    def __init__(self, tag, attrib={}, highlighted_file=None, start_byte=None, **extra):
+    def __init__(
+        self, tag, attrib={}, highlighted_file=None, start_byte=None, line_number=None, **extra
+    ):
         #
         # Example XML:
         #
@@ -65,24 +67,10 @@ class MyElement(Element):
         # Stores a highlighted_file instance, so that we can call .record on this element
         self.highlighted_file = highlighted_file
 
+        # Store the line number too
+        self.sourceline = line_number
+
         super(MyElement, self).__init__(tag, attrib, **extra)
-
-    def get_sourceline(self):
-        if self.highlighted_file is None:
-            raise ValueError(
-                "No HighlightedFile instance is associated with this Element "
-                "cannot get source line"
-            )
-
-        # Make sure the file_byte_contents member variable exists
-        self.highlighted_file.fill_char_array_if_needed()
-
-        # Convert to a string, split by newlines
-        lines = (
-            self.highlighted_file.file_byte_contents[: self.opening_tag_start].decode().split("\n")
-        )
-
-        return len(lines)
 
     def record(self, tool: str, field: str, value: str, units: str = None, xml_part="text"):
         """
@@ -255,6 +243,7 @@ class MyTreeBuilder:
             tag,
             attrs,
             start_byte=self._parser.parser.CurrentByteIndex,  # Pass the current byte index in to constructor
+            line_number=self._parser.parser.CurrentLineNumber,  # Pass the current line number in to the constructor
             highlighted_file=self._highlighted_file,
         )
         if self._elem:

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -31,13 +31,13 @@ def test_parser_source_line():
     doc = parse(ASCII_GPX_PATH, hf)
 
     trks = doc.findall(".//{*}trk")
-    assert trks[0].get_sourceline() == 10
+    assert trks[0].sourceline == 10
 
     trkpts = doc.findall(".//{*}trkpt")
-    assert trkpts[0].get_sourceline() == 13
+    assert trkpts[0].sourceline == 13
 
     elev_els = doc.findall(".//{*}ele")
-    assert elev_els[0].get_sourceline() == 14
+    assert elev_els[0].sourceline == 14
 
 
 def _check_element(el, file_contents):


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
The PR that was merged recently to improve the XML parser included a very inefficient method to get the source line for an XML element. I suddenly realised last night that I could get the sourceline directly from the underlying parser object - and this PR implements that, rather than calculating it manually ourself.

## 🤔 Reason: 
This will be far quicker and far more robust.

## 🔨Work carried out:

- [x] Changed code to access parser.CurrentLineNumber
- [x] Removed old get_sourceline method, as we now use the sourceline attribute
- [x] Updated tests
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
