### PR TITLE
Make conditions for Nisida importer stricter

### DIFF
--- a/importers/nisida_importer.py
+++ b/importers/nisida_importer.py
@@ -49,19 +49,16 @@ class NisidaImporter(Importer):
         self.platform = None
 
     def can_load_this_type(self, suffix):
-        return True
+        return suffix.upper() == ".TXT"
 
     def can_load_this_filename(self, filename):
         return True
 
     def can_load_this_header(self, header):
-        return True
+        return header.startswith("UNIT/")
 
     def can_load_this_file(self, file_contents):
-        for line in file_contents:
-            if line.startswith("UNIT/"):
-                return True
-        return False
+        return True
 
     def _load_this_line(self, data_store, line_number, line, datafile, change_id):
         self.current_line_no = line_number

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,7 +27,7 @@ def check_errors_for_file_contents(file_contents, expected_errors, importer, fil
         assert len(datafiles) == 0
 
     if filename is None:
-        filename = "test_input"
+        filename = "test_input.txt"
 
     with open(filename, "w") as f:
         f.write(file_contents)


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview:
The Nisida importer was trying to load every file it came across, as the only restriction was that there was a line starting `UNIT` somewhere in the file. This was slowing everything down, and also causing some problems with binary files.

This PR updates the `can_load_X` methods so that a Nisida file needs a .txt extension, and the `UNIT` text in the first line

## 🤔 Reason: 
- Speeds things up, as invalid files aren't attempted to be loaded
- Reduces the issues we have with binary files attempting to be loaded by other importers

## 🔨Work carried out:

- [x] Updated `can_load_X` functions
- [x] Updated test function to store in .txt file
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.