### PR TITLE
Handle invalid archive folder better

### DIFF
--- a/pepys_import/file/file_processor.py
+++ b/pepys_import/file/file_processor.py
@@ -67,9 +67,14 @@ class FileProcessor:
             # to be doing archiving
             if archive_path:
                 # Create the path if it doesn't exist
-                if not os.path.exists(archive_path):
-                    os.makedirs(archive_path)
-                self.output_path = archive_path
+                try:
+                    if not os.path.exists(archive_path):
+                        os.makedirs(archive_path)
+                    self.output_path = archive_path
+                except Exception as e:
+                    raise ValueError(
+                        f"Could not create archive folder at {archive_path}. Original error: {str(e)}"
+                    )
 
         self.skip_validation = skip_validation
 

--- a/pepys_import/file/file_processor.py
+++ b/pepys_import/file/file_processor.py
@@ -60,12 +60,17 @@ class FileProcessor:
         self.input_files_path = None
         self.directory_path = None
 
-        if archive_path:
-            # Create the path if it doesn't exist
-            if not os.path.exists(archive_path):
-                os.makedirs(archive_path)
-            self.output_path = archive_path
         self.archive = archive
+
+        if self.archive:
+            # Only create the archive folder if we are actually going
+            # to be doing archiving
+            if archive_path:
+                # Create the path if it doesn't exist
+                if not os.path.exists(archive_path):
+                    os.makedirs(archive_path)
+                self.output_path = archive_path
+
         self.skip_validation = skip_validation
 
     def process(self, path: str, data_store: DataStore = None, descend_tree: bool = True):

--- a/tests/config_file_tests/test_config_file.py
+++ b/tests/config_file_tests/test_config_file.py
@@ -108,7 +108,7 @@ class FileProcessorVariablesTestCase(unittest.TestCase):
         )
 
     def test_pepys_archive_location(self):
-        file_processor = FileProcessor(archive_path=OUTPUT_PATH)
+        file_processor = FileProcessor(archive_path=OUTPUT_PATH, archive=True)
         assert os.path.exists(OUTPUT_PATH) is True
         assert file_processor.output_path == OUTPUT_PATH
         # Remove the test_output directory

--- a/tests/config_file_tests/test_config_file.py
+++ b/tests/config_file_tests/test_config_file.py
@@ -114,6 +114,17 @@ class FileProcessorVariablesTestCase(unittest.TestCase):
         # Remove the test_output directory
         os.rmdir(OUTPUT_PATH)
 
+    def test_pepys_invalid_archive_location_not_archiving(self):
+        # Tests that an invalid archive location doesn't give
+        # an error if we've got archiving turned off
+        _ = FileProcessor(archive_path=r"///blahblah/blah", archive=False)
+
+    def test_pepys_invalid_archive_location_with_archiving(self):
+        # Tests that an invalid archive location gives an error
+        # if we're running with archiving turned on
+        with pytest.raises(ValueError, match="Could not create archive folder"):
+            _ = FileProcessor(archive_path=r"///blahblah/blah", archive=True)
+
     def test_no_archive_path_given(self):
         store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
         store.initialise()


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
Fixes to handle an invalid path to an archive folder better. Now gives a useful error message if we can't create the archive folder, and only tries to create the archive folder if archiving is actually turned on. This means that if there is a problem with the archive folder, imports can still be done using the 'no archive' option.

## 🤔 Reason: 
- Better error messages help the users
- Fixes a problem the users found with invalid archive settings stopping them doing any imports

## 🔨Work carried out:

- [x]  Moved archive creation inside an `if` statement
- [x] Added better error message
- [x] Added tests
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.