### PR TITLE
Fix NMEA importer to stop asking user about platform twice

### DIFF
--- a/importers/nmea_importer.py
+++ b/importers/nmea_importer.py
@@ -98,6 +98,10 @@ class NMEAImporter(Importer):
                 )
                 # Keep track of the platform name, so we don't have to ask for each line
                 self.platform_name = platform.name
+                # Explicitly store this new platform in the cache under the new platform name
+                # It won't be stored by default as the first time we called get_cached_platform
+                # we passed None as a name, and so it wouldn't have cached
+                self.platform_cache[self.platform_name] = platform
 
                 sensor = self.get_cached_sensor(
                     data_store=data_store,


### PR DESCRIPTION
## 🧰 Issue
#737 

## 🚀 Overview: 
The NMEA importer was asking the user twice about the platform, when it should only need to be told once. This change explicitly adds the returned platform to the platform cache, so it can be found next time (see developer notes below for more).

## 🤔 Reason: 
- Reduce user input needs

## 🔨Work carried out:

- [x] Add platform to the cache
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
This was tricky to debug because it seemed like the import was actually happening twice - there were two long progress bars, and Ian said in his original report that it was near the end of the import. Actually, the first long progress bar was the HighlightedFile characters array being filled (so we can do highlighting), and the second long progress bar was the actual import.

The code was like this:

```
platform = self.get_cached_platform(
    data_store, self.platform_name, change_id=change_id
)
# Keep track of the platform name, so we don't have to ask for each line
self.platform_name = platform.name
```
This is inside a loop over the lines in the file, and the first time round the loop we have `self.platform_name` set to `None`, which means the result can't be cached under a name - as we don't know a name until after we return from get_cached_platform. So, the next time round the loop we had a name, but the platform wasn't in the cache under that name. To fix this, we just add the line `self.platform_cache[self.platform_name] = platform` to explicitly put the platform in the cache under the new name.

