### PR TITLE
Fix positioning of Add button in GUI FilterWidget

### DIFF
--- a/pepys_admin/maintenance/widgets/filter_widget.py
+++ b/pepys_admin/maintenance/widgets/filter_widget.py
@@ -83,7 +83,7 @@ class FilterWidget:
         # The main container is a DynamicContainer, so it displays whatever the
         # result of a function is
         self.container = DynamicContainer(self.get_container_contents)
-        self.button = Button("Add filter condition", self.add_entry)
+        self.button = Button("Add filter condition", self.add_entry, width=22)
         self.set_contextual_help(self.button, CONTEXTUAL_HELP_STRING)
         self.validation_toolbar = ValidationToolbar()
 
@@ -133,7 +133,7 @@ class FilterWidget:
         content = HSplit(
             [
                 HSplit(display_widgets, padding=1),
-                self.button,
+                VSplit([self.button], align=HorizontalAlign.CENTER),
                 self.validation_toolbar,
             ],
             padding=1,


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
The prompt_toolkit maintainer is still working on a proper fix for the issues we've found with the positioning of buttons in the latest (master) version of prompt_toolkit. This PR changes the Button call to specify an exact width, which stops the button text being cut off. This can probably be removed in the future when prompt_toolkit deals with this automatically - but it fixes the problem for now.

This PR also switches to explicitly centering the button, rather than letting prompt_toolkit calculate a position automatically. This is a better approach overall, and so should stay regardless of what changes are made to prompt_toolkit.

## 🔗 Link to preview (or screenshot, if relevant)
![image](https://user-images.githubusercontent.com/296686/107626203-5b9d7d80-6c55-11eb-8f11-9516746ac129.png)


## 🤔 Reason: 
Makes the GUI look like it did before the change in prompt_toolkit broke it.

## 🔨Work carried out:

- [x] Adjusted button parameters
- [x] Added VSplit with align parameter
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database changes are recorded in the Log/Changes tables
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

