### PR TITLE
Create release from tags on develop or master

### DIFF
--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create release (only for tags)
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/master'
+        if: startsWith(github.ref, 'refs/tags/') && ( github.event.base_ref == 'refs/heads/master' || github.event.base_ref == 'refs/heads/develop' )
         with:
           draft: true
           files: ./*_pepys-import.zip


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
Currently releases are only created from tags on the `master` branch. This PR changes this so that tags on either `develop` or `master`.

## 🤔 Reason: 
- Makes it easier to create beta releases.
- 
## 🔨Work carried out:

- [x] Update Github Actions config
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database changes are recorded in the Log/Changes tables
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
@IanMayo This will need merging before it can be tested. I'm 90% sure it will work, but can't test until it is merged.