### PR TITLE
Fix error when opening GUI

### DIFF
--- a/pepys_admin/maintenance/gui.py
+++ b/pepys_admin/maintenance/gui.py
@@ -81,13 +81,16 @@ class MaintenanceGUI:
 
         self.data_store.setup_table_type_mapping()
 
-        # try:
-        #     # This calls a simple function to check if the Privacies table has entries
-        #     # We don't actually care if it has entries, but it is a good simple query
-        #     # to run which checks if the database has been initialised
-        #     _ = self.data_store.is_empty()
-        # except Exception:
-        #     raise ValueError("Cannot run GUI on a non-initialised database. Please run initialise first.")
+        try:
+            # This calls a simple function to check if the Privacies table has entries
+            # We don't actually care if it has entries, but it is a good simple query
+            # to run which checks if the database has been initialised
+            with self.data_store.session_scope():
+                _ = self.data_store.is_empty()
+        except Exception:
+            raise ValueError(
+                "Cannot run GUI on a non-initialised database. Please run initialise first."
+            )
 
         # Start with an empty table
         self.table_data = []


### PR DESCRIPTION
## 🧰 Issue
Fixes #802 

## 🚀 Overview: 
This ensures that when we check the database when we load the GUI, we check it inside a `session_scope()` - otherwise we can't always access the database properly. This caused the bug in the attached issue, because the Status command created a session which could be used.

## 🤔 Reason: 
Fix bug

## 🔨Work carried out:

- [x] Change to check database within a `session_scope()`
- [x] Tests pass
## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.