### PR TITLE
Add branch name and commit hash to deployment zip file name

### DIFF
--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Pepys Deployment
-          path: ./*_pepys-import.zip
+          path: ./pepys_import*.zip
 
       - name: Calculate release name
         id: get_name

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -227,7 +227,7 @@ try {
     # we're running on GH Actions), otherwise use a git command (the git command doesn't
     # work on Github actions)
     if (Test-Path env:GITHUB_REF) {
-        $gitbranch = $GITHUB_REF -replace "refs/heads/" ""
+        $gitbranch = $GITHUB_REF.Replace("refs/heads/", "")
     } else {
         $gitbranch = git branch --show-current
     }

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -227,7 +227,7 @@ try {
     # we're running on GH Actions), otherwise use a git command (the git command doesn't
     # work on Github actions)
     if (Test-Path env:GITHUB_REF) {
-        $gitbranch = $GITHUB_REF.Replace("refs/heads/", "")
+        $gitbranch = $env:GITHUB_REF.Replace("refs/heads/", "")
     } else {
         $gitbranch = git branch --show-current
     }

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -222,7 +222,9 @@ try {
     # Zip up whole folder into a zip-file with the current date in the filename
     # excluding the 7zip folder
     $date_str = Get-Date -Format "yyyyMMdd"
-    $output_filename = $date_str + "_pepys-import.zip"
+    $gitcommit = git rev-parse --short HEAD
+    $gitbranch = git branch --show-current
+    $output_filename = "pepys_import-$date_str-$gitbranch-$gitcommit.zip"
     .\7zip\7za.exe a .\$output_filename .\* -xr!7zip/ -xr!"bin\distlib-0.3.0-py2.py3-none-any.whl"
 
     if ($LastExitCode -ne 0)

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -223,7 +223,15 @@ try {
     # excluding the 7zip folder
     $date_str = Get-Date -Format "yyyyMMdd"
     $gitcommit = git rev-parse --short HEAD
-    $gitbranch = git branch --show-current
+    # Get the branch name from the GITHUB_REF env var if it exists (which it will if
+    # we're running on GH Actions), otherwise use a git command (the git command doesn't
+    # work on Github actions)
+    if (Test-Path env:GITHUB_REF) {
+        $gitbranch = $GITHUB_REF -replace "refs/heads/" ""
+    } else {
+        $gitbranch = git branch --show-current
+    }
+    
     $output_filename = "pepys_import-$date_str-$gitbranch-$gitcommit.zip"
     .\7zip\7za.exe a .\$output_filename .\* -xr!7zip/ -xr!"bin\distlib-0.3.0-py2.py3-none-any.whl"
 

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -223,10 +223,12 @@ try {
     # excluding the 7zip folder
     $date_str = Get-Date -Format "yyyyMMdd"
     $gitcommit = git rev-parse --short HEAD
-    # Get the branch name from the GITHUB_REF env var if it exists (which it will if
+    # Get the branch name from the GITHUB_HEAD_REF/GITHUB_REF env var if it exists (which it will if
     # we're running on GH Actions), otherwise use a git command (the git command doesn't
     # work on Github actions)
-    if (Test-Path env:GITHUB_REF) {
+    if (Test-Path env:GITHUB_HEAD_REF) {
+        $gitbranch = $env:GITHUB_HEAD_REF
+    } elseif (Test-Path env:GITHUB_REF) {
         $gitbranch = $env:GITHUB_REF.Replace("refs/heads/", "")
     } else {
         $gitbranch = git branch --show-current


### PR DESCRIPTION
## 🧰 Issue
Fixes #808 

## 🚀 Overview: 
Add the git branch and short commit hash to the name of the zip file created by the create_deployment script. (This will work on GH Actions and if the script is run manually on a Windows machine). The output filename will look like:

`pepys_import-20210310-branchname-ad34b5.zip`

## 🤔 Reason: 
Make it clearer which release of pepys we're using

## 🔨Work carried out:

- [x] Update create_deployment script
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
