### PR TITLE
Allow nested booleans in filter_widget_output_to_query

### DIFF
--- a/pepys_admin/maintenance/widgets/filter_widget_utils.py
+++ b/pepys_admin/maintenance/widgets/filter_widget_utils.py
@@ -25,61 +25,87 @@ and_or_dict = {
 def filter_widget_output_to_query(outputs: List[List], table_name: str, data_store: DataStore):
     class_name = table_name_to_class_name(table_name)
     class_obj = getattr(data_store.db_classes, class_name)
-    queries = list()
-    and_or_list = list()
-    for idx, output in enumerate(outputs):
-        if len(output) == 3:
-            column, ops, value = output
-            try:  # Try to get table field
-                col = getattr(class_obj, column)
-            except AttributeError:
-                raise AttributeError(f"Column not found! Error in {idx}: '{column}'")
-
-            # If we're trying to filter on a relationship column, then look for the
-            # relevant ID column to filter on instead
-            # This will either be the local column for the foreign key relationship
-            # or the manually-defined local column in the relationship's info
-            # dict, if it is a secondary relationship
-            try:
-                if isinstance(col.prop, sqlalchemy.orm.relationships.RelationshipProperty):
-                    if "local_column" in col.prop.info:
-                        id_col_name = col.prop.info["local_column"]
+    final_query_list = list()
+    final_and_or_list = list()
+    idx = 0
+    while idx < len(outputs):
+        output = outputs[idx]
+        if len(output) == 1 and output[0] == "(":
+            queries = list()
+            and_or_list = list()
+            while True:
+                idx += 1
+                output = outputs[idx]
+                if len(output) == 3:
+                    handle_three_variables(class_obj, output, idx, queries)
+                elif len(output) == 1:
+                    if output[0] in and_or_dict:
+                        and_or_list.append(and_or_dict[output[0]])
+                    elif output[0] == ")":
+                        final_query_list.append(get_query(queries, and_or_list))
+                        break
                     else:
-                        id_col_name = list(col.prop.local_columns)[0].key
-                    col = getattr(class_obj, id_col_name)
-            except Exception:
-                pass
-
-            if ops == "LIKE":
-                try:
-                    if isinstance(col.type, UUIDType):
-                        queries.append(cast(col, sqlalchemy.String).ilike(f"%{value}%"))
-                    else:
-                        queries.append(col.ilike(f"%{value}%"))
-                except Exception:
-                    queries.append(col.like(f"%{value}%"))
-
-            elif ops in operator_dict:
-                queries.append(operator_dict[ops](col, value))
-            else:
-                raise ValueError(f"Operator Error in {idx}: '{ops}'!")
-        elif len(output) == 1:
-            if output[0] in and_or_dict:
-                and_or_list.append(and_or_dict[output[0]])
-            else:
-                raise ValueError(f"Operator Error in {idx}: '{output}'!")
+                        raise ValueError(f"Operator Error in {idx}: '{output}'!")
+                else:
+                    raise ValueError(
+                        f"There should be one or three variables in each filter. Error in {idx}: '{output}'!"
+                    )
+        elif len(output) == 1 and output[0] in and_or_dict:
+            final_and_or_list.append(and_or_dict[output[0]])
+        elif len(output) == 3:
+            handle_three_variables(class_obj, output, idx, final_query_list)
         else:
             raise ValueError(
                 f"There should be one or three variables in each filter. Error in {idx}: '{output}'!"
             )
+        idx += 1
 
-    if len(queries) == 0:
-        return None
+    query = get_query(final_query_list, final_and_or_list)
+    return query
 
+
+def get_query(query_list: list, and_or_list: list):
     i, j = 1, 0
-    query = queries[0]
-    while i < len(queries) and j < len(and_or_list):
-        query = and_or_list[j](query, queries[i])
+    query = query_list[0]
+    while i < len(query_list) and j < len(and_or_list):
+        query = and_or_list[j](query, query_list[i])
         i += 1
         j += 1
     return query
+
+
+def handle_three_variables(class_obj, output, idx, query_list):
+    column, ops, value = output
+    try:  # Try to get table field
+        col = getattr(class_obj, column)
+    except AttributeError:
+        raise AttributeError(f"Column not found! Error in {idx}: '{column}'")
+
+    # If we're trying to filter on a relationship column, then look for the
+    # relevant ID column to filter on instead
+    # This will either be the local column for the foreign key relationship
+    # or the manually-defined local column in the relationship's info
+    # dict, if it is a secondary relationship
+    try:
+        if isinstance(col.prop, sqlalchemy.orm.relationships.RelationshipProperty):
+            if "local_column" in col.prop.info:
+                id_col_name = col.prop.info["local_column"]
+            else:
+                id_col_name = list(col.prop.local_columns)[0].key
+            col = getattr(class_obj, id_col_name)
+    except Exception:
+        pass
+
+    if ops == "LIKE":
+        try:
+            if isinstance(col.type, UUIDType):
+                query_list.append(cast(col, sqlalchemy.String).ilike(f"%{value}%"))
+            else:
+                query_list.append(col.ilike(f"%{value}%"))
+        except Exception:
+            query_list.append(col.like(f"%{value}%"))
+
+    elif ops in operator_dict:
+        query_list.append(operator_dict[ops](col, value))
+    else:
+        raise ValueError(f"Operator Error in {idx}: '{ops}'!")


### PR DESCRIPTION
## 🧰 Issue
Fixes #800 

## 🔨Work carried out:
- [x] Extend filter_widget_output_to_query
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->

