### PR TITLE
Add progress bar for dependent objects calculation - and speed it up

### DIFF
--- a/pepys_admin/maintenance/column_data.py
+++ b/pepys_admin/maintenance/column_data.py
@@ -187,7 +187,8 @@ def create_normal_column_data(col, data_store, table_object):
         # Skip all ID columns except the primary key
         return None, None
 
-    if details["type"] == "string":
+    # Skip getting values for the remarks column, as we don't need a dropdown for that
+    if details["type"] == "string" and details["system_name"] != "remarks":
         # Get values
 
         all_records = data_store.session.query(table_object).all()

--- a/pepys_admin/maintenance/dialogs/progress_dialog.py
+++ b/pepys_admin/maintenance/dialogs/progress_dialog.py
@@ -81,17 +81,6 @@ class ProgressDialog:
         app = get_app()
         app.invalidate()
 
-        # If we get to 100% then close the dialog
-        if value >= 100:
-            # Wrap this in a try/except, in case we've already set to
-            # 100% somewhere else, and therefore we try to set the Future
-            # value twice, giving an error
-            try:
-                # self.future.set_result(None)
-                pass
-            except Exception:
-                pass
-
     def is_cancelled(self):
         return self.cancelled
 

--- a/pepys_admin/maintenance/dialogs/progress_dialog.py
+++ b/pepys_admin/maintenance/dialogs/progress_dialog.py
@@ -58,7 +58,7 @@ class ProgressDialog:
             # while a potentially-blocking function runs in the background
             try:
                 loop = asyncio.get_running_loop()
-                await loop.run_in_executor(
+                result = await loop.run_in_executor(
                     None,
                     partial(
                         self.run_callback,
@@ -66,8 +66,12 @@ class ProgressDialog:
                         is_cancelled=self.is_cancelled,
                     ),
                 )
+                self.future.set_result(result)
             except Exception as e:
-                self.future.set_result(e)
+                try:
+                    self.future.set_result(e)
+                except asyncio.InvalidStateError:
+                    pass
 
         ensure_future(coroutine())
 
@@ -83,7 +87,8 @@ class ProgressDialog:
             # 100% somewhere else, and therefore we try to set the Future
             # value twice, giving an error
             try:
-                self.future.set_result(None)
+                # self.future.set_result(None)
+                pass
             except Exception:
                 pass
 

--- a/pepys_admin/maintenance/gui.py
+++ b/pepys_admin/maintenance/gui.py
@@ -61,6 +61,12 @@ from pepys_import.utils.table_name_utils import table_name_to_class_name
 logger.remove()
 logger.add("gui.log")
 
+# Uncomment the lines below to get logging of the SQL queries run by SQLAlchemy
+# to the file sql.log
+# import logging
+# logging.basicConfig(filename='sql.log', level=logging.DEBUG)
+# logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
+
 
 class MaintenanceGUI:
     def __init__(self, data_store=None):

--- a/pepys_admin/maintenance/gui.py
+++ b/pepys_admin/maintenance/gui.py
@@ -369,7 +369,7 @@ class MaintenanceGUI:
 
                 count = query_obj.count()
 
-                # Get all the results, while undefering all fields to make sure everything is
+                # Get the first 100 results, while undefering all fields to make sure everything is
                 # available once it's been expunged (disconnected) from the database
                 results = query_obj.options(undefer("*")).limit(100).all()
 
@@ -434,7 +434,7 @@ class MaintenanceGUI:
             dialog = ProgressDialog(
                 "Loading table data",
                 partial(self.get_column_data, self.current_table_object),
-                show_cancel=True,
+                show_cancel=False,
             )
             result = await self.show_dialog_as_float(dialog)
 
@@ -567,6 +567,15 @@ class MaintenanceGUI:
                 self.data_store.delete_objects(table_object, ids)
             set_percentage(100)
 
+        def do_find_dependent_objects(
+            table_object, selected_ids, set_percentage=None, is_cancelled=None
+        ):
+            dependent_objects = self.data_store.find_dependent_objects(
+                table_object, selected_ids, set_percentage=set_percentage, is_cancelled=is_cancelled
+            )
+            set_percentage(100)
+            return dependent_objects
+
         async def coroutine():
             entries = self.preview_table.current_values
 
@@ -594,9 +603,22 @@ class MaintenanceGUI:
                 getattr(entry, get_primary_key_for_table(self.current_table_object))
                 for entry in self.preview_table.current_values
             ]
-            dependent_objects = self.data_store.find_dependent_objects(
-                self.current_table_object, selected_ids
+
+            dialog = ProgressDialog(
+                "Finding dependent items (may take a while)",
+                partial(do_find_dependent_objects, self.current_table_object, selected_ids),
+                show_cancel=True,
             )
+            dependent_objects = await self.show_dialog_as_float(dialog)
+
+            if isinstance(dependent_objects, Exception):
+                await self.show_messagebox_async(
+                    "Error",
+                    f"Error deleting values\n\nOriginal error:{textwrap.fill(str(dependent_objects), 60)}",
+                )
+                return
+            elif dependent_objects is None:
+                return
 
             dep_objs_text = "\n".join(
                 f"{number} {table_name}" for table_name, number in dependent_objects.items()

--- a/pepys_import/core/store/data_store.py
+++ b/pepys_import/core/store/data_store.py
@@ -2109,15 +2109,21 @@ class DataStore:
         while objects:  # find all dependent objects and add them to object_list
             curr_obj = objects.pop(0)
 
+            # Get the list of foreign keys for the table from the cache, if it exists
+            # otherwise calculate it and put it into the cache
             if type(curr_obj) in foreign_keys_for_table:
                 foreign_keys = foreign_keys_for_table[type(curr_obj)]
             else:
                 foreign_keys = get_referencing_foreign_keys(curr_obj)
                 foreign_keys_for_table[type(curr_obj)] = foreign_keys
 
-            dependent_objs = list(dependent_objects(curr_obj, foreign_keys=foreign_keys))
-            objects.extend(dependent_objs)
-            object_list.extend(dependent_objs)
+            # If the current object has any foreign key relationships pointing to it
+            # then do the calculation - otherwise just skip (eg. for State which isn't
+            # referenced by anything)
+            if len(foreign_keys) > 0:
+                dependent_objs = list(dependent_objects(curr_obj, foreign_keys=foreign_keys))
+                objects.extend(dependent_objs)
+                object_list.extend(dependent_objs)
             if i % 10 == 0:
                 if callable(is_cancelled) and is_cancelled():
                     return None

--- a/tests/gui_tests/test_column_data.py
+++ b/tests/gui_tests/test_column_data.py
@@ -897,7 +897,6 @@ def test_column_data_state():
             "sqlalchemy_type": "column",
             "system_name": "remarks",
             "type": "string",
-            "values": [],
         },
         "sensor": {
             "foreign_table_type": TableTypes.METADATA,


### PR DESCRIPTION
## 🧰 Issue
Hopefully this will fix the problems the users were having in #817 - but they _said_ that it froze when they _selected_ the privacy table, whereas this fixes a free when you actually choose which ones to delete - so we'll have to get them to test it.

## 🚀 Overview: 
Added a progress bar while the dependent objects were being calculated. Also sped up the dependent objects calculation by around 3x (from 50s to 16s for my example), by caching some things that the sqlalchemy-utils function was calculating each time.

## 🔗 Link to preview (or screenshot, if relevant)
![MaintenanceGUI_2021-03-12](https://user-images.githubusercontent.com/296686/110956979-1a2aeb80-8343-11eb-884d-96a65680ccbf.gif)

## 🤔 Reason: 
Stops the GUI looking like it has frozen.

## 🔨Work carried out:
- [x] Added a progress bar dialog while the dependent objects calculation is carried out
- [x] Added caching of foreign key relations to the find_dependent_objects function
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
I've managed to find a way of doing a progress bar for this operation that doesn't go backwards, and still gives a reasonable idea of progress! We know how many objects we have in the list that we're going through (although we're adding to that list constantly), so we can use that as a sort-of denominator, with a big of extra logic so that the progress bar doesn't go backwards when we add a load of new objects to the list.
