### PR TITLE
Hotfix - fix floating point columns incorrectly appearing as filterable columns when using Postgres

### DIFF
--- a/pepys_admin/maintenance/column_data.py
+++ b/pepys_admin/maintenance/column_data.py
@@ -1,7 +1,7 @@
 import geoalchemy2
 import sqlalchemy
 from sqlalchemy import nullslast
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP, UUID
 
 from pepys_admin.maintenance.utils import get_display_name, remove_duplicates_and_nones
 from pepys_import.utils.sqlalchemy_utils import UUIDType, get_primary_key_for_table
@@ -15,9 +15,13 @@ def get_type_name(type_object):
         return "id"
     elif isinstance(type_object, sqlalchemy.sql.sqltypes.String):
         return "string"
-    elif isinstance(type_object, sqlalchemy.sql.sqltypes.DateTime):
+    elif isinstance(type_object, sqlalchemy.sql.sqltypes.DateTime) or isinstance(
+        type_object, TIMESTAMP
+    ):
         return "datetime"
-    elif isinstance(type_object, sqlalchemy.sql.sqltypes.REAL):
+    elif isinstance(type_object, sqlalchemy.sql.sqltypes.REAL) or isinstance(
+        type_object, DOUBLE_PRECISION
+    ):
         return "float"
     elif isinstance(type_object, sqlalchemy.sql.sqltypes.Integer):
         return "int"

--- a/pepys_admin/maintenance/column_data.py
+++ b/pepys_admin/maintenance/column_data.py
@@ -187,7 +187,8 @@ def create_normal_column_data(col, data_store, table_object):
         # Skip all ID columns except the primary key
         return None, None
 
-    if details["type"] == "string":
+    # Skip getting values for the remarks column, as we don't need a dropdown for that
+    if details["type"] == "string" and details["system_name"] != "remarks":
         # Get values
 
         all_records = data_store.session.query(table_object).all()


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
There was an error in the column data creation where the type of a database column was checked: the type checking didn't work with Postgres. This meant that some type-based logic wasn't working correctly: for example, floating point columns were appearing as options of columns to filter by, even though that isn't supported. This fixes that by comparing Postgres column types properly.

## 🤔 Reason: 
Fix bug

## 🔨Work carried out:

- [x] Alter type tests
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
