### PR TITLE
Hotfix - Fix crash on selecting complex foreign key item in filters

### DIFF
--- a/pepys_admin/maintenance/column_data.py
+++ b/pepys_admin/maintenance/column_data.py
@@ -151,8 +151,6 @@ def create_assoc_proxy_data(ap_name, ap_obj, data_store, table_object):
         else:
             # For all other columns, no special processing is needed
             all_records = data_store.session.query(ap_obj.target_class).all()
-            # Sort the values and IDs lists together, so that ids[x] is still the
-            # ID for values[x]
             values = [str_if_not_none(getattr(record, ap_obj.value_attr)) for record in all_records]
             sorted_values = sorted(set(values))
             details["values"] = sorted_values
@@ -262,7 +260,7 @@ def create_relationship_data(rel_name, data_store, table_object):
                 ]
                 str_entries.append(" / ".join(field_values))
             ids = [
-                getattr(entry, get_primary_key_for_table(foreign_table_object))
+                str(getattr(entry, get_primary_key_for_table(foreign_table_object)))
                 for entry in all_entries
             ]
 

--- a/tests/gui_tests/test_column_data.py
+++ b/tests/gui_tests/test_column_data.py
@@ -897,7 +897,6 @@ def test_column_data_state():
             "sqlalchemy_type": "column",
             "system_name": "remarks",
             "type": "string",
-            "values": [],
         },
         "sensor": {
             "foreign_table_type": TableTypes.METADATA,


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
A bug was found where selecting a complex foreign keyed dropdown item in the FilterWidget (eg. on the States table, choosing `platform` and then selecting a `NAME / ID / NATIONALITY` entry from the dropdown) led to a crash. This was because the SQL text display was failing to display a UUID object. Fixing this simply requires treating UUIDs as strings.

## 🤔 Reason: 
Bug fix

## 🔨Work carried out:

- [x] Wrap the UUID extraction from the database in `str`
- [x] Tests pass


## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
