### PR TITLE
Allow selecting of all entries (including non-visible ones) in the preview table

### DIFF
--- a/pepys_admin/maintenance/dialogs/edit_dialog.py
+++ b/pepys_admin/maintenance/dialogs/edit_dialog.py
@@ -1,3 +1,4 @@
+import uuid
 from asyncio import Future
 
 from prompt_toolkit.layout.containers import HSplit, VSplit
@@ -49,6 +50,11 @@ class EditDialog:
         if len(entries) < 10:
             display_strs = []
             for entry in entries:
+                if isinstance(entry, uuid.UUID):
+                    # Should never get here, as if we've got a small number of entries selected
+                    # then they will be from the objects in the preview table
+                    # But this is an extra check to stop a crash in a very strange situation
+                    continue
                 display_str = " - ".join(
                     [
                         get_str_for_field(getattr(entry, field_name))

--- a/pepys_admin/maintenance/widgets/entry_display_widget.py
+++ b/pepys_admin/maintenance/widgets/entry_display_widget.py
@@ -1,3 +1,5 @@
+import uuid
+
 from prompt_toolkit.layout.containers import HSplit, VSplit
 from prompt_toolkit.widgets import Label
 
@@ -28,11 +30,15 @@ class EntryDisplayWidget:
 
         for key, value in self.edit_data.items():
             values_list = [
-                get_str_for_field(getattr(entry, value["system_name"])) for entry in self.entries
+                get_str_for_field(getattr(entry, value["system_name"]))
+                for entry in self.entries
+                if not isinstance(entry, uuid.UUID)
             ]
             # Just list the unique values
             values_list = list(set(values_list))
             value = "; ".join(values_list)
+            if len(self.entries) > 10:
+                value += "..."
             # The widgets are just a series of Labels
             rows.append(VSplit([Label(key, width=max_width), Label(" = ", width=3), Label(value)]))
 

--- a/pepys_import/utils/data_store_utils.py
+++ b/pepys_import/utils/data_store_utils.py
@@ -2,6 +2,7 @@ import csv
 import json
 import os
 import sys
+import uuid
 from inspect import getfullargspec
 from math import ceil
 
@@ -10,6 +11,7 @@ from sqlalchemy import func, inspect, select
 
 from paths import MIGRATIONS_DIRECTORY
 from pepys_import.resolvers.command_line_input import create_menu
+from pepys_import.utils.sqlalchemy_utils import get_primary_key_for_table
 from pepys_import.utils.table_name_utils import table_name_to_class_name
 from pepys_import.utils.text_formatting_utils import (
     custom_print_formatted_text,
@@ -339,3 +341,20 @@ def convert_edit_dict_columns(edit_dict, table_object):
             update_dict[col_name] = new_value
 
     return update_dict
+
+
+def convert_objects_to_ids(items, table_obj):
+    if isinstance(items, list):
+        new_id_list = []
+        for value in items:
+            if not isinstance(value, uuid.UUID):
+                value = getattr(value, get_primary_key_for_table(table_obj))
+            new_id_list.append(value)
+
+        return new_id_list
+    else:
+        if not isinstance(items, uuid.UUID):
+            value = getattr(items, get_primary_key_for_table(table_obj))
+        else:
+            value = items
+        return value

--- a/tests/test_data_store_edit.py
+++ b/tests/test_data_store_edit.py
@@ -22,7 +22,9 @@ class EditDataTestCase(TestCase):
             self.store.session.expunge_all()
 
     def test_edit_platform_identifier_single(self):
-        self.store.edit_items([self.platforms[0]], {"identifier": "NEWIDENT"})
+        self.store.edit_items(
+            [self.platforms[0]], {"identifier": "NEWIDENT"}, self.store.db_classes.Platform
+        )
 
         all_platforms = self.store.session.query(self.store.db_classes.Platform).all()
         assert len((all_platforms)) == 4
@@ -39,7 +41,11 @@ class EditDataTestCase(TestCase):
         assert result[0].identifier == "NEWIDENT"
 
     def test_edit_platform_identifier_multiple(self):
-        self.store.edit_items([self.platforms[0], self.platforms[1]], {"identifier": "NEWIDENT"})
+        self.store.edit_items(
+            [self.platforms[0], self.platforms[1]],
+            {"identifier": "NEWIDENT"},
+            self.store.db_classes.Platform,
+        )
 
         all_platforms = self.store.session.query(self.store.db_classes.Platform).all()
         assert len((all_platforms)) == 4
@@ -60,7 +66,11 @@ class EditDataTestCase(TestCase):
         assert result[1].identifier == "NEWIDENT"
 
     def test_edit_platform_multiple_fields_single_object(self):
-        self.store.edit_items([self.platforms[0]], {"identifier": "NEWIDENT", "name": "TestName"})
+        self.store.edit_items(
+            [self.platforms[0]],
+            {"identifier": "NEWIDENT", "name": "TestName"},
+            self.store.db_classes.Platform,
+        )
 
         all_platforms = self.store.session.query(self.store.db_classes.Platform).all()
         assert len((all_platforms)) == 4
@@ -81,7 +91,9 @@ class EditDataTestCase(TestCase):
             self.store.session.query(self.store.db_classes.Nationality).options(undefer("*")).all()
         )
         new_nat_id = nationalities[-1].nationality_id
-        self.store.edit_items([self.platforms[0]], {"nationality": new_nat_id})
+        self.store.edit_items(
+            [self.platforms[0]], {"nationality": new_nat_id}, self.store.db_classes.Platform
+        )
 
         all_platforms = self.store.session.query(self.store.db_classes.Platform).all()
         assert len((all_platforms)) == 4
@@ -98,7 +110,9 @@ class EditDataTestCase(TestCase):
             self.store.session.query(self.store.db_classes.PlatformType).options(undefer("*")).all()
         )
         new_pt_id = plat_types[0].platform_type_id
-        self.store.edit_items([self.platforms[0]], {"platform_type": new_pt_id})
+        self.store.edit_items(
+            [self.platforms[0]], {"platform_type": new_pt_id}, self.store.db_classes.Platform
+        )
 
         all_platforms = self.store.session.query(self.store.db_classes.Platform).all()
         assert len((all_platforms)) == 4
@@ -117,6 +131,7 @@ class EditDataTestCase(TestCase):
             self.store.edit_items(
                 [self.platforms[0], self.platforms[1]],
                 {"identifier": "NEWIDENT", "name": "TestName"},
+                self.store.db_classes.Platform,
             )
 
     def test_edit_platform_type(self):
@@ -125,7 +140,7 @@ class EditDataTestCase(TestCase):
         )
         before_len = len(all_pts)
 
-        self.store.edit_items([all_pts[0]], {"name": "NewName"})
+        self.store.edit_items([all_pts[0]], {"name": "NewName"}, self.store.db_classes.PlatformType)
 
         all_pts = (
             self.store.session.query(self.store.db_classes.PlatformType).options(undefer("*")).all()


### PR DESCRIPTION
## 🧰 Issue
Fixes #827 

## 🚀 Overview: 
This PR allows the user to select entries that aren't shown in the preview table - for example, if they want to select all States that match the filter query, ready to export to a REP file. The work consists of three parts:

- Altering the CheckboxTable to allow the header bar checkbox to toggle between none selected, all visible selected and all (including non-visible) selected
- Creating a new way of retrieving the non-visible items from the database, if they have been selected and are needed for an action. In this case we only retrieve IDs (UUIDs) from the database, as this is far quicker, and we're only going to use the IDs in the processing anyway
- Ensuring all actions work with lists containing mixtures of objects and UUIDs

## 🔗 Link to preview (or screenshot, if relevant)
![MaintenanceGUI_2021-03-18](https://user-images.githubusercontent.com/296686/111642685-353fa480-87f6-11eb-816b-00d170094844.gif)

## 🤔 Reason: 
Allow the user to select very large numbers of items, ready for adding functionality for exporting measurements to CSV and REP files.

## 🔨Work carried out:

- [x] See above
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.