### PR TITLE
Display build date in Windows Command Prompt title bar

### DIFF
--- a/bin/pepys_admin.bat
+++ b/bin/pepys_admin.bat
@@ -1,4 +1,5 @@
 @echo off
+CALL set_title.bat Pepys Admin
 CALL set_paths.bat
 REM If error returned from set_paths.bat then don't continue with running python
 IF ERRORLEVEL 1 GOTO :ERROR

--- a/bin/pepys_admin_training.bat
+++ b/bin/pepys_admin_training.bat
@@ -1,4 +1,5 @@
 @echo off
+CALL set_title.bat Pepys Admin (training)
 CALL set_paths.bat
 REM If error returned from set_paths.bat then don't continue with running python
 IF ERRORLEVEL 1 GOTO :ERROR

--- a/bin/pepys_import.bat
+++ b/bin/pepys_import.bat
@@ -1,4 +1,5 @@
 @echo off
+CALL set_title.bat Pepys Import
 CALL set_paths.bat
 REM If error returned from set_paths.bat then don't continue with running python
 IF ERRORLEVEL 1 GOTO :ERROR

--- a/bin/pepys_import_no_archive_sendto.bat
+++ b/bin/pepys_import_no_archive_sendto.bat
@@ -1,4 +1,5 @@
 @echo off
+CALL set_title.bat Pepys Import
 CALL set_paths.bat
 REM If error returned from set_paths.bat then don't continue with running python
 IF ERRORLEVEL 1 GOTO :ERROR

--- a/bin/pepys_import_sendto.bat
+++ b/bin/pepys_import_sendto.bat
@@ -1,4 +1,5 @@
 @echo off
+CALL set_title.bat Pepys Import
 CALL set_paths.bat
 REM If error returned from set_paths.bat then don't continue with running python
 IF ERRORLEVEL 1 GOTO :ERROR

--- a/bin/pepys_import_training_sendto.bat
+++ b/bin/pepys_import_training_sendto.bat
@@ -1,4 +1,5 @@
 @echo off
+CALL set_title.bat Pepys Import (training)
 CALL set_paths.bat
 REM If error returned from set_paths.bat then don't continue with running python
 IF ERRORLEVEL 1 GOTO :ERROR

--- a/bin/pepys_viewer.bat
+++ b/bin/pepys_viewer.bat
@@ -1,4 +1,5 @@
 @echo off
+CALL set_title.bat Pepys Viewer
 CALL set_paths.bat
 REM If error returned from set_paths.bat then don't continue with running python
 IF ERRORLEVEL 1 GOTO :ERROR

--- a/bin/pepys_viewer_training.bat
+++ b/bin/pepys_viewer_training.bat
@@ -1,4 +1,5 @@
 @echo off
+CALL set_title.bat Pepys Viewer (training)
 CALL set_paths.bat
 REM If error returned from set_paths.bat then don't continue with running python
 IF ERRORLEVEL 1 GOTO :ERROR

--- a/bin/set_title.bat
+++ b/bin/set_title.bat
@@ -1,0 +1,1 @@
+title %* - Build: BUILDTIMESTAMP

--- a/bin/set_title.bat
+++ b/bin/set_title.bat
@@ -1,1 +1,2 @@
+REM Modify command prompt title, as documented here: https://ss64.com/nt/title.html
 title %* - Build: BUILDTIMESTAMP

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -211,6 +211,8 @@ try {
     # welcome text
     $timestamp_str = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
     (Get-Content .\pepys_import\__init__.py).replace('__build_timestamp__ = None', '__build_timestamp__ = "' + $timestamp_str + '"') | Set-Content .\pepys_import\__init__.py
+    (Get-Content .\bin\set_title.bat).replace('BUILDTIMESTAMP', $timestamp_str) | Set-Content .\bin\set_title.bat
+
 }
 catch {
     Write-Output $_


### PR DESCRIPTION
## 🧰 Issue
Fixes #835 

## 🚀 Overview: 
Displays the build date of Pepys in the titlebar of any Windows Command Prompt window that Pepys opens - this includes all the various different Pepys Admin shortcuts, Pepys Viewer, Pepys Import etc.

## 🔗 Link to preview (or screenshot, if relevant)
![image](https://user-images.githubusercontent.com/296686/112644411-49f6ea80-8e3d-11eb-8264-dd929c49ea1d.png)

## 🤔 Reason: 
Helps other developers and the users know exactly which version they're using.

## 🔨Work carried out:

- [x] Added new `set_title.bat` file to set the title (so we only have to change the build date in one place)
- [x] Called `set_title.bat` at the start of all of our other batch files
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
