### PR TITLE
Fix bug with filtering by platforms when viewing States in Postgres

### DIFF
--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -10,7 +10,6 @@ from tqdm import tqdm
 from config import LOCAL_BASIC_TESTS, LOCAL_ENHANCED_TESTS
 from pepys_import.core.formats import unit_registry
 from pepys_import.core.formats.location import Location
-from pepys_import.core.store import constants
 from pepys_import.core.validators import constants as validation_constants
 from pepys_import.core.validators.basic_validator import BasicValidator
 from pepys_import.core.validators.enhanced_validator import EnhancedValidator
@@ -651,21 +650,6 @@ class StateMixin:
         return association_proxy("sensor", "host")
 
     @declared_attr
-    def platform(self):
-        return relationship(
-            "Platform",
-            secondary=constants.SENSOR,
-            primaryjoin="State.sensor_id == Sensor.sensor_id",
-            secondaryjoin="Platform.platform_id == Sensor.host",
-            lazy="joined",
-            uselist=False,
-            viewonly=True,
-            # This specifies that when trying to query on this relationship
-            # this is the local column (well, assoc proxy actually) to filter on
-            info={"local_column": "platform_id"},
-        )
-
-    @declared_attr
     def platform_name(self):
         return association_proxy("platform", "name")
 
@@ -814,19 +798,6 @@ class ContactMixin:
     @declared_attr
     def platform_id(self):
         return association_proxy("sensor", "host")
-
-    @declared_attr
-    def platform(self):
-        return relationship(
-            "Platform",
-            secondary=constants.SENSOR,
-            primaryjoin="Contact.sensor_id == Sensor.sensor_id",
-            secondaryjoin="Platform.platform_id == Sensor.host",
-            lazy="joined",
-            join_depth=1,
-            uselist=False,
-            viewonly=True,
-        )
 
     @declared_attr
     def platform_name(self):

--- a/pepys_import/core/store/postgres_db.py
+++ b/pepys_import/core/store/postgres_db.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from geoalchemy2 import Geometry
 from sqlalchemy import DATE, Boolean, Column, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP, UUID
-from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import (  # used to defer fetching attributes unless it's specifically called
     deferred,
@@ -589,6 +588,12 @@ class State(BasePostGIS, StateMixin, ElevationPropertyMixin, LocationPropertyMix
     remarks = Column(Text)
     created_date = Column(DateTime, default=datetime.utcnow)
 
+    # This relationship has to be defined here rather than in
+    # common_db.py, as we're using the 'secondary' parameter,
+    # which has to take a table name. With Postgres it requires a
+    # full 'schema.table' name, and as SQLite doesn't have
+    # schemas, this will fail for SQLite. Thus it is defined
+    # in sqlite_db.py and postgres_db.py.
     @declared_attr
     def platform(self):
         return relationship(
@@ -597,14 +602,12 @@ class State(BasePostGIS, StateMixin, ElevationPropertyMixin, LocationPropertyMix
             primaryjoin="State.sensor_id == Sensor.sensor_id",
             secondaryjoin="Platform.platform_id == Sensor.host",
             lazy="joined",
-            join_depth=1,
             uselist=False,
             viewonly=True,
+            # This specifies that when trying to query on this relationship
+            # this is the local column (well, assoc proxy actually) to filter on
+            info={"local_column": "platform_id"},
         )
-
-    @declared_attr
-    def platform_name(self):
-        return association_proxy("platform", "name")
 
 
 class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropertyMixin):
@@ -658,6 +661,12 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropert
     remarks = Column(Text)
     created_date = Column(DateTime, default=datetime.utcnow)
 
+    # This relationship has to be defined here rather than in
+    # common_db.py, as we're using the 'secondary' parameter,
+    # which has to take a table name. With Postgres it requires a
+    # full 'schema.table' name, and as SQLite doesn't have
+    # schemas, this will fail for SQLite. Thus it is defined
+    # in sqlite_db.py and postgres_db.py.
     @declared_attr
     def platform(self):
         return relationship(
@@ -669,11 +678,10 @@ class Contact(BasePostGIS, ContactMixin, LocationPropertyMixin, ElevationPropert
             join_depth=1,
             uselist=False,
             viewonly=True,
+            # This specifies that when trying to query on this relationship
+            # this is the local column (well, assoc proxy actually) to filter on
+            info={"local_column": "platform_id"},
         )
-
-    @declared_attr
-    def platform_name(self):
-        return association_proxy("platform", "name")
 
 
 class Activation(BasePostGIS, ActivationMixin):

--- a/pepys_import/core/store/sqlite_db.py
+++ b/pepys_import/core/store/sqlite_db.py
@@ -4,8 +4,10 @@ from uuid import uuid4
 from geoalchemy2 import Geometry
 from sqlalchemy import DATE, Boolean, Column, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.sqlite import REAL, TIMESTAMP
+from sqlalchemy.ext.declarative.api import declared_attr
 from sqlalchemy.orm import (  # used to defer fetching attributes unless it's specifically called
     deferred,
+    relationship,
 )
 from sqlalchemy.sql.schema import CheckConstraint, UniqueConstraint
 
@@ -587,6 +589,27 @@ class State(BaseSpatiaLite, StateMixin, ElevationPropertyMixin, LocationProperty
     remarks = Column(Text)
     created_date = Column(DateTime, default=datetime.utcnow)
 
+    # This relationship has to be defined here rather than in
+    # common_db.py, as we're using the 'secondary' parameter,
+    # which has to take a table name. With Postgres it requires a
+    # full 'schema.table' name, and as SQLite doesn't have
+    # schemas, this will fail for SQLite. Thus it is defined
+    # in sqlite_db.py and postgres_db.py.
+    @declared_attr
+    def platform(self):
+        return relationship(
+            "Platform",
+            secondary="Sensors",
+            primaryjoin="State.sensor_id == Sensor.sensor_id",
+            secondaryjoin="Platform.platform_id == Sensor.host",
+            lazy="joined",
+            uselist=False,
+            viewonly=True,
+            # This specifies that when trying to query on this relationship
+            # this is the local column (well, assoc proxy actually) to filter on
+            info={"local_column": "platform_id"},
+        )
+
 
 class Contact(BaseSpatiaLite, ContactMixin, LocationPropertyMixin, ElevationPropertyMixin):
     __tablename__ = constants.CONTACT
@@ -632,6 +655,28 @@ class Contact(BaseSpatiaLite, ContactMixin, LocationPropertyMixin, ElevationProp
     )
     remarks = Column(Text)
     created_date = deferred(Column(DateTime, default=datetime.utcnow))
+
+    # This relationship has to be defined here rather than in
+    # common_db.py, as we're using the 'secondary' parameter,
+    # which has to take a table name. With Postgres it requires a
+    # full 'schema.table' name, and as SQLite doesn't have
+    # schemas, this will fail for SQLite. Thus it is defined
+    # in sqlite_db.py and postgres_db.py.
+    @declared_attr
+    def platform(self):
+        return relationship(
+            "Platform",
+            secondary=constants.SENSOR,
+            primaryjoin="Contact.sensor_id == Sensor.sensor_id",
+            secondaryjoin="Platform.platform_id == Sensor.host",
+            lazy="joined",
+            join_depth=1,
+            uselist=False,
+            viewonly=True,
+            # This specifies that when trying to query on this relationship
+            # this is the local column (well, assoc proxy actually) to filter on
+            info={"local_column": "platform_id"},
+        )
 
 
 class Activation(BaseSpatiaLite, ActivationMixin):


### PR DESCRIPTION
## 🧰 Issue
#841 

## 🚀 Overview: 
Fix a bug which only occurred with Postgres, when filtering by platform when viewing States in the GUI no results were returned. The fix required adding the `info` dict to the relevant `relationship`, but this also required some tidying of `relationship` definitions (see Developer Notes below).

## 🤔 Reason: 
Fix bug

## 🔨Work carried out:

- [x] Add `info` dict to `relationship` in Postgres, so that it uses the right local field
- [x] Tidy up and move `relationship` definitions
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
This bug was caused by the Postgres relationship definition not including the `info` dict required to give the right information to some of our internal functions that work out how to turn the UI output into a SQLAlchemy filter. This was because there were actually two definitions of the relationship - one in the postgres-specific State class, and one in the StateMixin. The Postgres-specific one overrode the one in the mixin, and this didn't have the `info` dict defined.

I tried to switch to using a relationship just defined in the mixin, as this would cleaner. However, this wasn't possible as this relationship definition uses the `secondary` argument which requires db-specific arguments (it needs a schema in a string for Postgres, but not SQLite). Therefore, this commit moves the relationships that have these `secondary` arguments into the sqlite_db.py and postgres_db.py files, and remove them entirely from the mixin in common_db.py.
