### PR TITLE
Hotfix: Increase edit dialog size in Maintenance GUI

### DIFF
--- a/pepys_admin/maintenance/dialogs/edit_dialog.py
+++ b/pepys_admin/maintenance/dialogs/edit_dialog.py
@@ -85,7 +85,7 @@ class EditDialog:
             title=f"Edit {table_object.__name__}(s)",
             body=self.body,
             buttons=[ok_button, cancel_button],
-            width=D(preferred=120),
+            width=D(preferred=160),
             modal=True,
         )
 


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
The Edit Dialog in the Maintenance GUI was too small to display the field name for 'default data interval secs' in Platform Types. This makes the dialog a bit wider so that it can display properly (before an error was displayed saying 'Window too small').

## 🔗 Link to preview (or screenshot, if relevant)
![image](https://user-images.githubusercontent.com/296686/114369552-66ea2800-9b76-11eb-9fc2-0ee588bc1676.png)

## 🤔 Reason: 
Makes it possible for the user to edit the PlatformType values - which is how we're recommending they get set up with the new field.

## 🔨Work carried out:

- [x] Made dialog wider
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
