### PR TITLE
Hotfix: Fix GUI bug where deleting objects caused a crash on SQLite

### DIFF
--- a/pepys_admin/maintenance/gui.py
+++ b/pepys_admin/maintenance/gui.py
@@ -666,9 +666,13 @@ class MaintenanceGUI:
         def do_find_dependent_objects(
             table_object, selected_ids, set_percentage=None, is_cancelled=None
         ):
-            dependent_objects = self.data_store.find_dependent_objects(
-                table_object, selected_ids, set_percentage=set_percentage, is_cancelled=is_cancelled
-            )
+            with self.data_store.session_scope():
+                dependent_objects = self.data_store.find_dependent_objects(
+                    table_object,
+                    selected_ids,
+                    set_percentage=set_percentage,
+                    is_cancelled=is_cancelled,
+                )
             set_percentage(100)
             return dependent_objects
 


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
The Maintenance GUI crashed when deleting an object if you were running under SQLite. This was caused by changes to make finding dependent objects for deletion more user-friendly by running it in a separate thread behind a progress bar. This wasn't using the session object properly, and therefore was doing strange things with un-thread-safe objects.

## 🤔 Reason: 
Fix bug

## 🔨Work carried out:

- [x] Find dependent objects properly within a session
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
