### PR TITLE
Fix release name zip file for tags

### DIFF
--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -42,7 +42,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && ( github.event.base_ref == 'refs/heads/master' || github.event.base_ref == 'refs/heads/develop' )
         with:
           draft: true
-          files: ./*_pepys-import.zip
+          files: ./pepys-import*.zip
           name: ${{ steps.get_name.outputs.release_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -231,7 +231,7 @@ try {
     if (Test-Path env:GITHUB_HEAD_REF) {
         $gitbranch = $env:GITHUB_HEAD_REF
     } elseif (Test-Path env:GITHUB_REF) {
-        $gitbranch = $env:GITHUB_REF.Replace("refs/heads/", "")
+        $gitbranch = $env:GITHUB_REF.Replace("refs/heads/", "").Replace("refs/tags/", "")
     } else {
         $gitbranch = git branch --show-current
     }


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
The zip files created by the create_deployment script were being created with the wrong name when a tag was being used. This fixes that, so they get picked up correctly by Github Actions and added to the release.

## 🤔 Reason: 
Fix CI

## 🔨Work carried out:

- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
