### PR TITLE
Fix glob pattern to have _ not - in the zip file name

### DIFF
--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -42,7 +42,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && ( github.event.base_ref == 'refs/heads/master' || github.event.base_ref == 'refs/heads/develop' )
         with:
           draft: true
-          files: ./pepys-import*.zip
+          files: ./pepys_import*.zip
           name: ${{ steps.get_name.outputs.release_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Another fix for the uploading of releases - this time to change `-` to `_` in the glob for the zip file to upload.