### PR TITLE
Make the Create Deployment CI action fail if it can't find files to upload

### DIFF
--- a/.github/workflows/create_deployment.yml
+++ b/.github/workflows/create_deployment.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           name: Pepys Deployment
           path: ./pepys_import*.zip
+          if-no-files-found: error
 
       - name: Calculate release name
         id: get_name
@@ -44,5 +45,6 @@ jobs:
           draft: true
           files: ./pepys_import*.zip
           name: ${{ steps.get_name.outputs.release_name }}
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🧰 Issue
Fixes #850 

## 🚀 Overview: 
Update the Github Actions config for the Create Deployment CI action to fail if it can't find files to upload for the artifact upload process or the release upload process (if a tag has been pushed).

## 🤔 Reason: 
Stop CI failing silently.

## 🔨Work carried out:

- [x] Update Github Actions workflow config
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

