### PR TITLE
Hotfix: Fix error when deleting participants

### DIFF
--- a/pepys_admin/maintenance/widgets/participants_widget.py
+++ b/pepys_admin/maintenance/widgets/participants_widget.py
@@ -393,10 +393,15 @@ class ParticipantsWidget:
         ds = self.task_edit_widget.data_store
         participant = self.participants[self.combo_box.selected_entry]
 
+        change_id = ds.add_to_changes(
+            USER, datetime.utcnow(), "Manual delete from Tasks GUI"
+        ).change_id
+
         with ds.session_scope():
             ds.delete_objects(
                 participant.__tablename__,
                 [getattr(participant, get_primary_key_for_table(participant))],
+                change_id=change_id,
             )
 
             ds.session.add(self.task_edit_widget.task_object)


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
An error occurs when deleting participants in the new Tasks GUI. I'm sure this was working when I tested before the last release, so I don't know how this slipped through. Anyway, it's a simple fix - so hopefully we can roll it out quickly.

## 🤔 Reason: 
Fix bug

## 🔨Work carried out:

- [x] Make sure to include a change ID when calling the deletion function
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
