### PR TITLE
Fix disappearing edits to participants when clicking a new serial

### DIFF
--- a/pepys_admin/maintenance/tasks_gui.py
+++ b/pepys_admin/maintenance/tasks_gui.py
@@ -287,7 +287,6 @@ class TasksGUI:
             self.data_store.session.refresh(new_serial)
 
             new_serial_id = new_serial.serial_id
-            logger.debug(f"{new_serial_id=}")
 
             # Copy the participants too
             orig_participants = current_task.participants

--- a/pepys_admin/maintenance/tasks_gui.py
+++ b/pepys_admin/maintenance/tasks_gui.py
@@ -181,6 +181,7 @@ class TasksGUI:
             self.handle_save,
             self.handle_delete,
             self.handle_duplicate,
+            self.update_tree_object,
             self.data_store,
             self.show_dialog_as_float,
         )
@@ -219,6 +220,10 @@ class TasksGUI:
             "You must provide valid values for the following fields before saving or\nadding a participant:\n\n"
             + "\n".join(missing_fields),
         )
+
+    def update_tree_object(self):
+        """Handles updating the Task object stored in the TreeView when it has changed"""
+        self.tree_view.selected_element.object = self.task_edit_widget.task_object
 
     def validate_fields(self, current_task, updated_fields):
         WARGAME_REQUIRED_FIELDS = set(["name", "start", "end"])

--- a/pepys_admin/maintenance/widgets/participants_widget.py
+++ b/pepys_admin/maintenance/widgets/participants_widget.py
@@ -175,6 +175,8 @@ class ParticipantsWidget:
                     ds, result["platform"], result["privacy"], change_id
                 )
 
+            self.task_edit_widget.update_tree_object_handler()
+
         async def coroutine_serial():
             ds = self.task_edit_widget.data_store
 
@@ -210,6 +212,8 @@ class ParticipantsWidget:
                     end=result["end"],
                     change_id=change_id,
                 )
+
+            self.task_edit_widget.update_tree_object_handler()
 
         # We need to save the task before adding a participant, or we don't have the database
         # ID to link the participant to the task. So we call the save method.
@@ -325,6 +329,8 @@ class ParticipantsWidget:
                 ds.session.refresh(self.task_edit_widget.task_object)
                 ds.session.expunge_all()
 
+            self.task_edit_widget.update_tree_object_handler()
+
         async def coroutine_wargame():
             ds = self.task_edit_widget.data_store
             participant = self.participants[self.combo_box.selected_entry]
@@ -396,6 +402,8 @@ class ParticipantsWidget:
                 ds.session.refresh(self.task_edit_widget.task_object)
                 ds.session.expunge_all()
 
+            self.task_edit_widget.update_tree_object_handler()
+
         if not self.item_selected_in_combo_box():
             return
 
@@ -435,6 +443,8 @@ class ParticipantsWidget:
         if new_selected_entry < 0:
             new_selected_entry = 0
         self.combo_box.selected_entry = new_selected_entry
+
+        self.task_edit_widget.update_tree_object_handler()
         get_app().invalidate()
 
     def handle_switch_button(self):

--- a/pepys_admin/maintenance/widgets/participants_widget.py
+++ b/pepys_admin/maintenance/widgets/participants_widget.py
@@ -478,6 +478,8 @@ class ParticipantsWidget:
                 change_id=change_id,
             )
 
+        self.task_edit_widget.update_tree_object_handler()
+
     def item_selected_in_combo_box(self):
         if len(self.combo_box.filtered_entries) == 0:
             return False

--- a/pepys_admin/maintenance/widgets/participants_widget.py
+++ b/pepys_admin/maintenance/widgets/participants_widget.py
@@ -467,7 +467,7 @@ class ParticipantsWidget:
             participant = ds.session.merge(participant)
 
             change_id = ds.add_to_changes(
-                USER, datetime.utcnow(), "Manual delete from Tasks GUI"
+                USER, datetime.utcnow(), "Manual switch of participant force from Tasks GUI"
             ).change_id
 
             ds.add_to_logs(

--- a/pepys_admin/maintenance/widgets/task_edit_widget.py
+++ b/pepys_admin/maintenance/widgets/task_edit_widget.py
@@ -18,6 +18,7 @@ class TaskEditWidget:
         save_button_handler,
         delete_button_handler,
         duplicate_button_handler,
+        update_tree_object_handler,
         data_store,
         show_dialog_as_float,
     ):
@@ -26,6 +27,7 @@ class TaskEditWidget:
         self.save_button_handler = save_button_handler
         self.delete_button_handler = delete_button_handler
         self.duplicate_button_handler = duplicate_button_handler
+        self.update_tree_object_handler = update_tree_object_handler
         self.data_store = data_store
         # Reference to the main show_dialog_as_float method, so we can show a dialog from
         # the ParticipantsWidget


### PR DESCRIPTION
## 🧰 Issue
Fixes #865

## 🚀 Overview: 
Fixes a bug where editing the list of participants (eg. deleting or adding a member) and then switching to another serial and switching back again would still show the old list of participants (as opposed to the updated list) - even though the changes had been done in the database. Fixed by making sure we always update the object stored in the TreeView, so it is 'in sync' with the database at all times.

## 🤔 Reason: 
Fix bug

## 🔨Work carried out:

- [x] Add code to update the object stored in the TreeElement in the TreeView when we change the participants
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.