### PR TITLE
When editing boolean fields in Maintenance GUI, accept True/T/False/F as strings

### DIFF
--- a/pepys_admin/maintenance/dialogs/edit_dialog.py
+++ b/pepys_admin/maintenance/dialogs/edit_dialog.py
@@ -101,7 +101,9 @@ class EditDialog:
         try:
             output = self.entry_edit_widget.output
         except Exception as e:
-            self.error_message.text = f"Error converting values, please edit and try again.\nError was {str(e)}"
+            self.error_message.text = (
+                f"Error converting values, please edit and try again.\nError was {str(e)}"
+            )
             return
         self.future.set_result(output)
 

--- a/pepys_admin/maintenance/dialogs/edit_dialog.py
+++ b/pepys_admin/maintenance/dialogs/edit_dialog.py
@@ -100,8 +100,8 @@ class EditDialog:
     def handle_ok(self):
         try:
             output = self.entry_edit_widget.output
-        except Exception:
-            self.error_message.text = "Error converting values, please edit and try again"
+        except Exception as e:
+            self.error_message.text = f"Error converting values, please edit and try again.\nError was {str(e)}"
             return
         self.future.set_result(output)
 

--- a/pepys_admin/maintenance/widgets/entry_edit_widget.py
+++ b/pepys_admin/maintenance/widgets/entry_edit_widget.py
@@ -163,6 +163,8 @@ class EntryEditWidgetRow:
                     return True
                 elif self.value_widget.text.lower() in ("false", "f"):
                     return False
+                else:
+                    raise ValueError("Invalid boolean value entered")
             return self.value_widget.text
 
     def get_widgets(self):

--- a/pepys_admin/maintenance/widgets/entry_edit_widget.py
+++ b/pepys_admin/maintenance/widgets/entry_edit_widget.py
@@ -158,6 +158,11 @@ class EntryEditWidgetRow:
             if self.col_config["type"] == "datetime":
                 parsed_value = datetime.strptime(self.value_widget.text, "%Y-%m-%d %H:%M:%S")
                 return parsed_value
+            elif self.col_config["type"] == "bool":
+                if self.value_widget.text.lower() in ("true", "t"):
+                    return True
+                elif self.value_widget.text.lower() in ("false", "f"):
+                    return False
             return self.value_widget.text
 
     def get_widgets(self):


### PR DESCRIPTION
## 🧰 Issue
Fixes #868.

## 🚀 Overview: 
Adds the ability to edit boolean fields in the Maintenance GUI. You can edit the field by typing a new value of `True`/`T`/`False`/`F` (in any case - upper/lower/mixed). See notes below as to why this hasn't been implemented with a checkbox.

## 🤔 Reason: 
Fix bug where it was impossible to edit this field.

## 🔨Work carried out:

- [x] Parse appropriate strings as boolean, if the column is marked as a boolean column
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
The obvious way to implement editing boolean fields would be to provide a checkbox - and that's how I started doing this. However, there is a problem with this: the structure for our editing dialog is to have the current values on the left-hand side, and then fields for inserting new values on the right-hand side. If the field on the right-hand side is edited (ie. isn't still at the 'Enter new value' prompt) then we detect that as a desired change, and update the field in the database. The problem is, there isn't a way to have a 'prompt for entry' state with a checkbox - it can either be checked or unchecked. Thus, we don't know if the user has changed it or not - there is no 'in-between' state.

There are a few of ways to solve this:
- We could check/uncheck the checkbox when we load the form depending on the current value of the field in the database. However, there are two problems with this: 1) we don't currently have access to the current fields in the database within the widget that represents that side of the edit dialog - we've deliberately kept them very separate, so we don't have to deal with database stuff in that widget, and 2) it could be confusing as all the other fields on the right-hand side only have values in them when the user has edited them, so it would look like the user had edited the boolean field even when they hadn't.
- We could create a checkbox with three states: checked, unchecked and 'unknown' (you may have seen this before in some other UI frameworks). This would solve our problem, but would be quite a bit of work for something that is likely to be fairly rarely used (as there is a checkbox for setting this within the Tasks GUI).
- We could fallback to the simple option of having a string field and allowing any value that can be interpreted as boolean in there - `True`/`T`/`False`/`F` in any case. This should still be fairly easy for the user, as the field will be displayed as having a current value of `True`/`False` on the left-hand side, so they should be able to work out what to type.

I chose the final option, as that was a PR of 2 lines of code, as opposed to many many lines of code for the other options.

