### PR TITLE
Try and display database status regardless of whether we think the database is initialised

### DIFF
--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -131,8 +131,12 @@ class AdminShell(BaseShell):
                 formatted_text = format_table("## Reference", table_string=report)
                 custom_print_formatted_text(formatted_text)
 
-            print("## Database Version")
+        print("## Database Version")
+        try:
             command.current(self.cfg, verbose=True)
+        except Exception as e:
+            print("Error getting latest database version")
+            print(str(e))
 
         print("## Config file")
         print(f"Location: {config.CONFIG_FILE_PATH}")

--- a/pepys_import/utils/data_store_utils.py
+++ b/pepys_import/utils/data_store_utils.py
@@ -184,7 +184,6 @@ def is_schema_created(engine, db_type):
     inspector = inspect(engine)
     if db_type == "sqlite":
         table_names = inspector.get_table_names()
-        print(f"{len(table_names)=}")
         # SQLite can have either 78 tables (if using the new version of mod_spatialite)
         # or 76 (with the old stable release of mod_spatialite). The version of mod_spatialiate
         # that is installed can vary by platform - so both numbers should be acceptable.
@@ -192,7 +191,6 @@ def is_schema_created(engine, db_type):
             return True
     else:
         table_names = inspector.get_table_names(schema="pepys")
-        print(f"{len(table_names)=}")
         # # We expect 42 tables on Postgres
         if len(table_names) == 40:
             return True

--- a/tests/test_admin_cli.py
+++ b/tests/test_admin_cli.py
@@ -336,12 +336,6 @@ class NotInitialisedDBTestCase(unittest.TestCase):
 
         temp_output = StringIO()
         with redirect_stdout(temp_output):
-            self.admin_shell.do_status()
-        output = temp_output.getvalue()
-        assert "Database tables are not found! (Hint: Did you initialise the DataStore?)" in output
-
-        temp_output = StringIO()
-        with redirect_stdout(temp_output):
             self.initialise_shell.do_clear_db_contents()
         output = temp_output.getvalue()
         assert "Database tables are not found! (Hint: Did you initialise the DataStore?)" in output


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
When viewing Status from Pepys Admin, display the alembic database status regardless of whether we think the database is initialised or not - as this helps with debugging.

## 🔗 Link to preview (or screenshot, if relevant)
![image](https://user-images.githubusercontent.com/296686/116524744-a1bac280-a8cf-11eb-8802-447e019b849d.png)
This screenshot shows that an error is being produced saying that the table summaries can't be printed, but the database status is still displayed.

## 🤔 Reason: 
Helps with debugging

## 🔨Work carried out:

- [x] Move database status code outside of if statement, and wrap in try/except block
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
