### PR TITLE
Stop multiple rows being created in alembic version

### DIFF
--- a/pepys_import/utils/data_store_utils.py
+++ b/pepys_import/utils/data_store_utils.py
@@ -257,6 +257,11 @@ def create_alembic_version_table(engine, db_type):
                             f"Database revision in alembic_version table ({table_contents[0][0]}) does not match latest revision ({versions['LATEST_SQLITE_VERSION']}).\n"
                             "Please run database migration."
                         )
+                if len(table_contents) > 1:
+                    raise ValueError(
+                        "Multiple rows detected in alembic_version table. Database potentially in inconsistent state.\n"
+                        "Migration functionality will not work. Please contact support."
+                    )
         except sqlalchemy.exc.OperationalError:
             with engine.connect() as connection:
                 # Error running select, so table doesn't exist - create it and stamp the current version
@@ -305,6 +310,11 @@ def create_alembic_version_table(engine, db_type):
                         f"Database revision in alembic_version table ({table_contents[0][0]}) does not match latest revision ({versions['LATEST_POSTGRES_VERSION']}).\n"
                         "Please run database migration."
                     )
+            if len(table_contents) > 1:
+                raise ValueError(
+                    "Multiple rows detected in alembic_version table. Database potentially in inconsistent state.\n"
+                    "Migration functionality will not work. Please contact support."
+                )
         except sqlalchemy.exc.OperationalError:
             # Error running select, so table doesn't exist - create it and stamp the current version
             connection.execute(

--- a/pepys_import/utils/data_store_utils.py
+++ b/pepys_import/utils/data_store_utils.py
@@ -8,6 +8,7 @@ from math import ceil
 
 import sqlalchemy
 from sqlalchemy import func, inspect, select
+from sqlalchemy.sql.expression import text
 
 from paths import MIGRATIONS_DIRECTORY
 from pepys_import.resolvers.command_line_input import create_menu
@@ -238,13 +239,8 @@ def create_alembic_version_table(engine, db_type):
 
                 if len(table_contents) == 0:
                     # Table exists but no version number row, so stamp it:
-                    connection.execute(
-                        """
-                    INSERT INTO alembic_version (version_num)
-                    VALUES ('{id}')""".format(
-                            id=versions["LATEST_SQLITE_VERSION"]
-                        )
-                    )
+                    sql = text("INSERT INTO alembic_version (version_num) VALUES (:id)")
+                    connection.execute(sql, id=versions["LATEST_SQLITE_VERSION"])
                 if len(table_contents) == 1:
                     if table_contents[0][0] == versions["LATEST_SQLITE_VERSION"]:
                         # Current version already stamped in table - so just continue
@@ -274,13 +270,8 @@ def create_alembic_version_table(engine, db_type):
                     );
                 """
                 )
-                connection.execute(
-                    """
-                    INSERT INTO alembic_version (version_num)
-                    VALUES ('{id}')""".format(
-                        id=versions["LATEST_SQLITE_VERSION"]
-                    )
-                )
+                sql = text("INSERT INTO alembic_version (version_num) VALUES (:id)")
+                connection.execute(sql, id=versions["LATEST_SQLITE_VERSION"])
     else:
         # Try and get all entries from alembic_version table
         try:
@@ -291,13 +282,8 @@ def create_alembic_version_table(engine, db_type):
 
                 if len(table_contents) == 0:
                     # Table exists but no version number row, so stamp it:
-                    connection.execute(
-                        """
-                    INSERT INTO pepys.alembic_version (version_num)
-                    VALUES ('{id}')""".format(
-                            id=versions["LATEST_POSTGRES_VERSION"]
-                        )
-                    )
+                    sql = text("INSERT INTO pepys.alembic_version (version_num) VALUES (:id)")
+                    connection.execute(sql, id=versions["LATEST_POSTGRES_VERSION"])
                 if len(table_contents) == 1:
                     if table_contents[0][0] == versions["LATEST_POSTGRES_VERSION"]:
                         # Current version already stamped in table - so just continue
@@ -327,13 +313,8 @@ def create_alembic_version_table(engine, db_type):
                     );
                 """
                 )
-                connection.execute(
-                    """
-                    INSERT INTO alembic_version (version_num)
-                    VALUES ('{id}')""".format(
-                        id=versions["LATEST_POSTGRES_VERSION"]
-                    )
-                )
+                sql = text("INSERT INTO pepys.alembic_version (version_num) VALUES (:id)")
+                connection.execute(sql, id=versions["LATEST_POSTGRES_VERSION"])
 
 
 def cache_results_if_not_none(cache_attribute):

--- a/tests/test_datastore_utils.py
+++ b/tests/test_datastore_utils.py
@@ -1,0 +1,203 @@
+import json
+import os
+import re
+import unittest
+
+import pytest
+from testing.postgresql import Postgresql
+
+from paths import MIGRATIONS_DIRECTORY
+from pepys_import.core.store.data_store import DataStore
+from pepys_import.utils.data_store_utils import create_alembic_version_table
+
+with open(os.path.join(MIGRATIONS_DIRECTORY, "latest_revisions.json"), "r") as file:
+    versions = json.load(file)
+
+
+def test_create_alembic_version_empty_db():
+    ds = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+
+    create_alembic_version_table(ds.engine, ds.db_type)
+
+    with ds.engine.connect() as connection:
+        results = connection.execute("SELECT * FROM alembic_version;").fetchall()
+
+        assert len(results) == 1
+        assert results[0][0] == versions["LATEST_SQLITE_VERSION"]
+
+
+def test_create_alembic_version_table_empty():
+    ds = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+
+    # Create table and stamp version
+    create_alembic_version_table(ds.engine, ds.db_type)
+
+    # Delete all entries, so table is empty
+    with ds.engine.connect() as connection:
+        connection.execute("DELETE FROM alembic_version;")
+
+    # Now run function
+    create_alembic_version_table(ds.engine, ds.db_type)
+
+    # Check it has one entry and it's the right one
+    with ds.engine.connect() as connection:
+        results = connection.execute("SELECT * FROM alembic_version;").fetchall()
+
+        assert len(results) == 1
+        assert results[0][0] == versions["LATEST_SQLITE_VERSION"]
+
+
+def test_create_alembic_version_already_at_latest_version():
+    ds = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+
+    # Run once to create the table and stamp latest version, then run again
+    create_alembic_version_table(ds.engine, ds.db_type)
+
+    create_alembic_version_table(ds.engine, ds.db_type)
+
+    with ds.engine.connect() as connection:
+        results = connection.execute("SELECT * FROM alembic_version;").fetchall()
+
+        assert len(results) == 1
+        assert results[0][0] == versions["LATEST_SQLITE_VERSION"]
+
+
+def test_create_alembic_version_at_old_version():
+    ds = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+
+    # Run once to create the table and stamp latest version
+    create_alembic_version_table(ds.engine, ds.db_type)
+
+    with ds.engine.connect() as connection:
+        connection.execute("UPDATE alembic_version SET version_num = 'old_version_id';")
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Database revision in alembic_version table (old_version_id) does not match latest revision"
+        ),
+    ):
+        create_alembic_version_table(ds.engine, ds.db_type)
+
+
+def test_create_alembic_version_multiple_rows():
+    ds = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+
+    # Run once to create the table and stamp latest version
+    create_alembic_version_table(ds.engine, ds.db_type)
+
+    with ds.engine.connect() as connection:
+        connection.execute("INSERT INTO alembic_version VALUES ('new_entry');")
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Multiple rows detected in alembic_version table. Database potentially in inconsistent state.Migration functionality will not work. Please contact support."
+        ),
+    ):
+        create_alembic_version_table(ds.engine, ds.db_type)
+
+
+@pytest.mark.postgres
+class TestCreateAlembicVersionTable_Postgres(unittest.TestCase):
+    def setUp(self):
+        self.postgres = None
+        self.store = None
+        try:
+            self.postgres = Postgresql(
+                database="test",
+                host="localhost",
+                user="postgres",
+                password="postgres",
+                port=55527,
+            )
+        except RuntimeError:
+            print("PostgreSQL database couldn't be created! Test is skipping.")
+            return
+        try:
+            self.store = DataStore(
+                db_name="test",
+                db_host="localhost",
+                db_username="postgres",
+                db_password="postgres",
+                db_port=55527,
+                db_type="postgres",
+            )
+            self.store.initialise()
+        except Exception:
+            print("Database schema and data population failed! Test is skipping.")
+
+    def tearDown(self):
+        try:
+            self.postgres.stop()
+        except AttributeError:
+            return
+
+    def test_create_alembic_version_empty_db(self):
+        create_alembic_version_table(self.store.engine, self.store.db_type)
+
+        with self.store.engine.connect() as connection:
+            results = connection.execute("SELECT * FROM pepys.alembic_version;").fetchall()
+
+            assert len(results) == 1
+            assert results[0][0] == versions["LATEST_POSTGRES_VERSION"]
+
+    def test_create_alembic_version_table_empty(self):
+        # Create table and stamp version
+        create_alembic_version_table(self.store.engine, self.store.db_type)
+
+        # Delete all entries, so table is empty
+        with self.store.engine.connect() as connection:
+            connection.execute("DELETE FROM pepys.alembic_version;")
+
+        # Now run function
+        create_alembic_version_table(self.store.engine, self.store.db_type)
+
+        # Check it has one entry and it's the right one
+        with self.store.engine.connect() as connection:
+            results = connection.execute("SELECT * FROM pepys.alembic_version;").fetchall()
+
+            assert len(results) == 1
+            assert results[0][0] == versions["LATEST_POSTGRES_VERSION"]
+
+    def test_create_alembic_version_already_at_latest_version(self):
+        # Run once to create the table and stamp latest version, then run again
+        create_alembic_version_table(self.store.engine, self.store.db_type)
+
+        create_alembic_version_table(self.store.engine, self.store.db_type)
+
+        with self.store.engine.connect() as connection:
+            results = connection.execute("SELECT * FROM pepys.alembic_version;").fetchall()
+
+            assert len(results) == 1
+            assert results[0][0] == versions["LATEST_POSTGRES_VERSION"]
+
+    def test_create_alembic_version_at_old_version(self):
+        # Run once to create the table and stamp latest version
+        create_alembic_version_table(self.store.engine, self.store.db_type)
+
+        with self.store.engine.connect() as connection:
+            connection.execute("UPDATE alembic_version SET version_num = 'old_version_id';")
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Database revision in alembic_version table (old_version_id) does not match latest revision"
+            ),
+        ):
+            create_alembic_version_table(self.store.engine, self.store.db_type)
+
+    def test_create_alembic_version_multiple_rows(self):
+        # Run once to create the table and stamp latest version
+        create_alembic_version_table(self.store.engine, self.store.db_type)
+
+        with self.store.engine.connect() as connection:
+            connection.execute("INSERT INTO alembic_version VALUES ('new_entry');")
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Multiple rows detected in alembic_version table. Database potentially in inconsistent state.Migration functionality will not work. Please contact support."
+            ),
+        ):
+            create_alembic_version_table(self.store.engine, self.store.db_type)


### PR DESCRIPTION
## 🧰 Issue
Fixes #866. Fixes #873.

## 🚀 Overview: 
Improves the way we create the alembic_version table. Now handles all situations (table not existing, table empty, table with one row with latest version, table with one row with non-latest version, table with multiple rows) and does the right thing and gives sensible messages to the user.

This should mean we _never_ end up with multiple rows in the alembic_version table.

## 🤔 Reason: 
Fix issues that the users have experienced.

## 🔨Work carried out:

- [x] Rework `create_alembic_version_table` to handle all situations sensibly
- [x] Add new tests
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.