### PR TITLE
Hardcode timeline range to yesterday

### DIFF
--- a/pepys_timeline/static/js/src/pepys.js
+++ b/pepys_timeline/static/js/src/pepys.js
@@ -1,6 +1,9 @@
 moment.locale("en");
 
-const DATETIME_FORMAT = "YYYY-MM-DD HH:mm:ss";
+const DATE_FORMATS = {
+    visavail: "YYYY-MM-DD HH:mm:ss",
+    metadata: "YYYY-MM-DD"
+}
 
 let generatedCharts = false;
 let charts;
@@ -85,8 +88,14 @@ function fetchSerialsMeta() {
 
     const url = new URL(window.location + 'dashboard_metadata');
     const queryParams = new URLSearchParams();
-    queryParams.set('from_date', '2021-01-05');
-    queryParams.set('to_date', '2021-01-05');
+
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(today.getDate() - 1);
+
+    queryParams.set('from_date', moment(yesterday).format(DATE_FORMATS.metadata));
+    queryParams.set('to_date', moment(yesterday).format(DATE_FORMATS.metadata));
+
     url.search = queryParams.toString();
 
     fetch(url)
@@ -178,9 +187,9 @@ function transformParticipant(participant, serial) {
         && s.resp_serial_id === participant.serial_name
     )
     let periods = participantStats.map(s => ([
-            moment(s.resp_start_time).format(DATETIME_FORMAT),
+            moment(s.resp_start_time).format(DATE_FORMATS.visavail),
             Number(s.resp_range_type === "C"),
-            moment(s.resp_end_time).format(DATETIME_FORMAT),
+            moment(s.resp_end_time).format(DATE_FORMATS.visavail),
         ]));
     participant.coverage = periods;
 


### PR DESCRIPTION
## 🧰 Issue
Fixes #888.

## 🚀 Overview: 
Hardcodes the to/from times in the timeline dashboard to yesterday's dates. This is a transfer of the changes in [this PR](https://github.com/debrief/pepys-timeline/pull/28) into this repo.

## 🤔 Reason: 
Allow the users to see recent data.

## 🔨Work carried out:

- [x] Copy JS code changes over
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.