### PR TITLE
Fix SQLite table missing test so that it works on Windows too

### DIFF
--- a/tests/test_import_cli.py
+++ b/tests/test_import_cli.py
@@ -422,9 +422,12 @@ class TestImportWithMissingDBTableSQLite(unittest.TestCase):
         conn = sqlite3.connect("cli_import_test.db")
         load_spatialite(conn, None)
 
-        # We want to DROP a column from the States table, but SQLite doesn't support this
-        # so we drop the table and create a new table instead
+        # We need to drop multiple tables, as on Windows we have a different number of tables
+        # to start with, and therefore deleting just one table still comes within the range
+        # of table counts that we count as valid in is_schema_created
+        conn.execute("DROP TABLE Serials;")
         conn.execute("DROP TABLE Geometries;")
+        conn.execute("DROP TABLE PlatformTypes;")
         conn.close()
 
         temp_output = StringIO()


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
Fixes the CI test failure we had yesterday. One of our new tests was failing on Windows because of platform-specific differences in the number of tables created in SQLite.

## 🤔 Reason: 
Fix test

## 🔨Work carried out:

- [x] Remove more tables in the test, so that we definitely get below the number of tables that we accept as valid
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.