### PR TITLE
Stop dashboard being used if SQLite database is being used

### DIFF
--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -72,6 +72,10 @@ class AdminShell(BaseShell):
         self.cfg.attributes["connection"] = data_store.engine
 
     def do_view_dashboard(self):
+        if self.data_store.db_type == "sqlite":
+            print("The Pepys dashboard cannot be used with a SQLite database")
+            return
+
         app = create_app()
 
         print(


### PR DESCRIPTION
## 🧰 Issue
Fixes #893 

## 🚀 Overview: 
Checks to see if the database being used is a SQLite database, and if so gives an error if you try to load the dashboard.

## 🤔 Reason: 
Stop further errors occurring when dashboard is used with SQLite

## 🔨Work carried out:

- [x] Add check for db_type
- [x] Tests pass

## 🖥️ Screenshot
![image](https://user-images.githubusercontent.com/296686/117282880-202ddc00-ae5d-11eb-8ec3-a73391663bd8.png)


## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.