### PR TITLE
Remove unused data-received button from dashboard

### DIFF
--- a/pepys_timeline/static/css/style.css
+++ b/pepys_timeline/static/css/style.css
@@ -22,11 +22,6 @@ h1,h2,h3,h4,h5 {
   margin-bottom: 0;
 }
 
-#data-received-button {
-  font-size: 0.8em;
-  font-weight: bold;
-}
-
 .visavail {
     box-shadow: 0 -5px 6px 0px rgb(0 0 0 / 30%);
 }

--- a/pepys_timeline/templates/index.html
+++ b/pepys_timeline/templates/index.html
@@ -52,13 +52,6 @@
 			<div class="form-group" id="date-range-form-group">
 				<input type="text" class="form-control" name="date-range" value="" />
 			</div>
-			<button
-				type="button"
-				class="btn btn-raised btn-success btn-sm"
-				id="data-received-button"
-				onclick="onDataReceived()">
-				Data Received
-			</button>
 		</nav>
 		<div class="m-4"></div>
 		<div class="container-fluid">


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `#1`)] 
     [Please use `fixes` if it fully resolves an issue (e.g. `fixes #321`)]
-->
fixes #899 

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->
Removes unused 'Data Received' button from the dashboard toolbar.

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->
Originally the button was supposed to be used by the analysts to fetch new data. However, with the implementation of date pickers, they have an alternative way of doing this and the button is not needed anymore.

## 🔨Work carried out:

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->

- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->
![image](https://user-images.githubusercontent.com/13034472/117331027-3a33e280-ae8e-11eb-932d-f2b298093116.png)

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [ ] I have extended/updated the documentation in `\docs` folder
- [ ] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [ ] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
