### PR TITLE
Add ranges to date pickers

### DIFF
--- a/pepys_timeline/static/js/src/pepys.js
+++ b/pepys_timeline/static/js/src/pepys.js
@@ -26,6 +26,48 @@ let toDate = moment(yesterday);
 /* eslint-disable-next-line no-undef */
 const timer = new easytimer.Timer();
 
+$(function() {
+  $('input[name="date-range"]').daterangepicker({
+    opens: 'left',
+    locale: {
+      format: DATE_FORMATS.picker,
+    },
+    ranges: {
+        'Today': [moment(), moment()],
+        'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+        'Last 7 Days': [moment().subtract(6, 'days'), moment()],
+        'Last 30 Days': [moment().subtract(29, 'days'), moment()],
+        'This Week': [moment().startOf('week'), moment().endOf('week')],
+        'Last Week': [
+          moment().subtract(1, 'week').startOf('week'),
+          moment().subtract(1, 'week').endOf('week')
+        ],
+        'This Month': [moment().startOf('month'), moment().endOf('month')],
+        'Last Month': [
+          moment().subtract(1, 'month').startOf('month'),
+          moment().subtract(1, 'month').endOf('month')
+        ]
+    },
+    startDate: fromDate.format(DATE_FORMATS.picker),
+    endDate: toDate.format(DATE_FORMATS.picker),
+    buttonClasses: "btn",
+    applyButtonClasses: "btn-success",
+    cancelButtonClasses: "btn-danger",
+  }, function(newFromDate, newToDate, label) {
+    fromDate = newFromDate;
+    toDate = newToDate;
+  });
+
+  $('input[name="date-range"]').on('apply.daterangepicker', function(ev, picker) {
+      $(this).val(
+        picker.startDate.format(DATE_FORMATS.picker)
+        + ' - '
+        + picker.endDate.format(DATE_FORMATS.picker)
+      );
+      fetchSerialsMeta();
+  });
+});
+
 const defaultOptions = {
     margin: {
         right: 60,

--- a/pepys_timeline/static/js/src/pepys.js
+++ b/pepys_timeline/static/js/src/pepys.js
@@ -1,3 +1,8 @@
+/* eslint-env browser */
+/* eslint no-undef: "error" */
+/* global moment */
+/* global easytimer */
+
 moment.locale("en");
 
 const DATE_FORMATS = {
@@ -5,9 +10,11 @@ const DATE_FORMATS = {
   metadata: "YYYY-MM-DD",
   picker: "DD/MM/YYYY",
 }
-const DEFAULT_MESSAGE_OF_THE_DAY = 'Message of the day: [PENDING]';
+const DEFAULT_MESSAGE_OF_THE_DAY = "Message of the day: [PENDING]";
 
-const messageOfTheDayEl = document.getElementById('message-of-the-day');
+const countdownNumberEl = document.getElementById("countdown-number");
+const progress = document.querySelector("#countdown-progress");
+const messageOfTheDayEl = document.getElementById("message-of-the-day");
 
 let config;
 let generatedCharts;
@@ -23,50 +30,7 @@ yesterday.setDate(today.getDate() - 1);
 let fromDate = moment(yesterday);
 let toDate = moment(yesterday);
 
-/* eslint-disable-next-line no-undef */
 const timer = new easytimer.Timer();
-
-$(function() {
-  $('input[name="date-range"]').daterangepicker({
-    opens: 'left',
-    locale: {
-      format: DATE_FORMATS.picker,
-    },
-    ranges: {
-        'Today': [moment(), moment()],
-        'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
-        'Last 7 Days': [moment().subtract(6, 'days'), moment()],
-        'Last 30 Days': [moment().subtract(29, 'days'), moment()],
-        'This Week': [moment().startOf('week'), moment().endOf('week')],
-        'Last Week': [
-          moment().subtract(1, 'week').startOf('week'),
-          moment().subtract(1, 'week').endOf('week')
-        ],
-        'This Month': [moment().startOf('month'), moment().endOf('month')],
-        'Last Month': [
-          moment().subtract(1, 'month').startOf('month'),
-          moment().subtract(1, 'month').endOf('month')
-        ]
-    },
-    startDate: fromDate.format(DATE_FORMATS.picker),
-    endDate: toDate.format(DATE_FORMATS.picker),
-    buttonClasses: "btn",
-    applyButtonClasses: "btn-success",
-    cancelButtonClasses: "btn-danger",
-  }, function(newFromDate, newToDate, label) {
-    fromDate = newFromDate;
-    toDate = newToDate;
-  });
-
-  $('input[name="date-range"]').on('apply.daterangepicker', function(ev, picker) {
-      $(this).val(
-        picker.startDate.format(DATE_FORMATS.picker)
-        + ' - '
-        + picker.endDate.format(DATE_FORMATS.picker)
-      );
-      fetchSerialsMeta();
-  });
-});
 
 const defaultOptions = {
     margin: {
@@ -121,10 +85,10 @@ function setMessageOfTheDay() {
 
 function updateDatetime() {
   const date = new Date();
-  const dateDiv = document.getElementById('date');
-  const timeDiv = document.getElementById('time');
-  dateDiv.innerHTML = moment(date).format('YYYY / MM / DD');
-  timeDiv.innerHTML = moment(date).format('HH:mm:ss');
+  const dateDiv = document.getElementById("date");
+  const timeDiv = document.getElementById("time");
+  dateDiv.textContent = moment(date).format("YYYY / MM / DD");
+  timeDiv.textContent = moment(date).format("HH:mm:ss");
 }
 
 function startDatetimeClock() {
@@ -132,10 +96,7 @@ function startDatetimeClock() {
   setInterval(updateDatetime, 1000);
 }
 
-const countdownNumberEl = document.getElementById("countdown-number");
-const progress = document.querySelector("#countdown-progress");
-
-const updateCountdownProgress = (seconds) => {
+function updateCountdownProgress(seconds) {
   const period = config.frequency_secs;
   const timePct = period !== 0 ? seconds/period : 0;
   const total = Math.PI * (2 * progress.r.baseVal.value);
@@ -143,15 +104,16 @@ const updateCountdownProgress = (seconds) => {
   progress.style.strokeDashoffset = progressPct;
 }
 
-const resetCountdown = () => {
+function resetCountdown() {
   countdownNumberEl.textContent = config.frequency_secs;
   updateCountdownProgress(config.frequency_secs);
 }
 
-const onTimerStarted = (event) => {
+function onTimerStarted(event) {
   resetCountdown();
 }
-const onTimerSecondsUpdated = (event) => {
+
+function onTimerSecondsUpdated(event) {
   const { detail } = event;
   const { timer: t } = detail;
   const { seconds } = t.getTimeValues();
@@ -159,26 +121,23 @@ const onTimerSecondsUpdated = (event) => {
   updateCountdownProgress(seconds);
 }
 
-const onTimerTargetAchieved = () => {
+function onTimerTargetAchieved() {
   timer.reset();
   fetchSerialsMeta();
 }
 
-const onTimerReset = (event) => {
+function onTimerReset(event) {
   resetCountdown();
 }
 
-const getTimerConfig = (seconds) => ({
-  startValues: { seconds },
-  target: { seconds: 0 },
-  precision: "seconds",
-  countdown: true,
-});
-
-timer.addEventListener("secondsUpdated", onTimerSecondsUpdated);
-timer.addEventListener("started", onTimerStarted);
-timer.addEventListener("targetAchieved", onTimerTargetAchieved);
-timer.addEventListener("reset", onTimerReset);
+function getTimerConfig(seconds) {
+  return {
+    startValues: { seconds },
+    target: { seconds: 0 },
+    precision: "seconds",
+    countdown: true,
+  };
+}
 
 function resetState() {
     config = null;
@@ -187,6 +146,55 @@ function resetState() {
     chartOptions = [];
     serialsMeta = [];
     serialsStats = [];
+}
+
+function initDateRange() {
+  $("input[name=\"date-range\"]").daterangepicker({
+    opens: "left",
+    locale: {
+      format: DATE_FORMATS.picker,
+    },
+    ranges: {
+        "Today": [moment(), moment()],
+        "Yesterday": [moment().subtract(1, "days"), moment().subtract(1, "days")],
+        "Last 7 Days": [moment().subtract(6, "days"), moment()],
+        "Last 30 Days": [moment().subtract(29, "days"), moment()],
+        "This Week": [moment().startOf("week"), moment().endOf("week")],
+        "Last Week": [
+          moment().subtract(1, "week").startOf("week"),
+          moment().subtract(1, "week").endOf("week")
+        ],
+        "This Month": [moment().startOf("month"), moment().endOf("month")],
+        "Last Month": [
+          moment().subtract(1, "month").startOf("month"),
+          moment().subtract(1, "month").endOf("month")
+        ]
+    },
+    startDate: fromDate.format(DATE_FORMATS.picker),
+    endDate: toDate.format(DATE_FORMATS.picker),
+    buttonClasses: "btn",
+    applyButtonClasses: "btn-success",
+    cancelButtonClasses: "btn-danger",
+  }, function(newFromDate, newToDate, label) {
+    fromDate = newFromDate;
+    toDate = newToDate;
+  });
+
+  $("input[name=\"date-range\"]").on("apply.daterangepicker", function(ev, picker) {
+      $(this).val(
+        picker.startDate.format(DATE_FORMATS.picker)
+        + " - "
+        + picker.endDate.format(DATE_FORMATS.picker)
+      );
+      onTimerTargetAchieved();
+  });
+}
+
+function initTimer() {
+  timer.addEventListener("secondsUpdated", onTimerSecondsUpdated);
+  timer.addEventListener("started", onTimerStarted);
+  timer.addEventListener("targetAchieved", onTimerTargetAchieved);
+  timer.addEventListener("reset", onTimerReset);
 }
 
 function fetchConfig() {
@@ -370,7 +378,6 @@ function transformSerials() {
     return transformedData;
 }
 
-
 function renderCharts() {
     clearCharts();
     const transformedSerials = transformSerials();
@@ -403,38 +410,13 @@ function renderCharts() {
 function clearCharts() {
   console.log("Clearing charts.");
   var chartDiv = document.getElementById("chart_row");
-  chartDiv.innerHTML = "";
+  chartDiv.textContent = "";
 }
 
 $(function() {
-  $('input[name="date-range"]').daterangepicker({
-    opens: "left",
-    locale: {
-      format: DATE_FORMATS.picker,
-    },
-    startDate: fromDate.format(DATE_FORMATS.picker),
-    endDate: toDate.format(DATE_FORMATS.picker),
-    buttonClasses: "btn",
-    applyButtonClasses: "btn-success",
-    cancelButtonClasses: "btn-danger",
-
-  }, function(newFromDate, newToDate, label) {
-    fromDate = newFromDate;
-    toDate = newToDate;
-  });
-
-  $('input[name="date-range"]').on("apply.daterangepicker", function(ev, picker) {
-      $(this).val(
-        picker.startDate.format(DATE_FORMATS.picker)
-        + " - "
-        + picker.endDate.format(DATE_FORMATS.picker)
-      );
-      onTimerTargetAchieved();
-  });
-});
-
-window.onload = (event) => {
   resetState();
+  initDateRange();
+  initTimer();
   startDatetimeClock();
   fetchConfig();
-};
+});


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `#1`)] 
     [Please use `fixes` if it fully resolves an issue (e.g. `fixes #321`)]
-->
Fixes #900

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->
This PR adds predefined date range selections into the date range dropdown, including:

- today
- yesterday
- last 7 days
- last 30 days
- this week
- last week
- this month
- last month
- custom range (which, if selected, opens the double calendar view that we have been using exclusively so far)

## 🔗 Link to preview (or screenshot, if relevant)
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->
Lower cognitive load for the user.

## 🔨Work carried out:

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->

- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->
![image](https://user-images.githubusercontent.com/13034472/117580736-5a171080-b0f1-11eb-8dc3-18d00be17ad8.png)
![image](https://user-images.githubusercontent.com/13034472/117580744-64390f00-b0f1-11eb-9ea1-b162d936528e.png)

## Confirmations

- [x] I have chosen reviewers for my PR.
- [ ] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [ ] I have extended/updated the documentation in `\docs` folder
- [ ] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [ ] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

