### PR TITLE
Extend Pepys Viewer to include more view-only options

### DIFF
--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -51,6 +51,7 @@ class AdminShell(BaseShell):
         super(AdminShell, self).__init__()
         self.data_store = data_store
         self.csv_path = csv_path
+        self.viewer = False
         self.aliases = {
             ".": self.do_exit,
             "1": self.do_initialise,
@@ -196,7 +197,7 @@ class AdminShell(BaseShell):
         if is_schema_created(self.data_store.engine, self.data_store.db_type) is False:
             return
         print("-" * 60)
-        shell = ViewDataShell(self.data_store)
+        shell = ViewDataShell(self.data_store, viewer=self.viewer)
         shell.cmdloop()
 
     @staticmethod

--- a/pepys_admin/cli.py
+++ b/pepys_admin/cli.py
@@ -6,7 +6,7 @@ from prompt_toolkit import prompt
 
 import config
 from pepys_admin.admin_cli import AdminShell
-from pepys_admin.view_data_cli import ViewDataShell
+from pepys_admin.viewer_cli import ViewerShell
 from pepys_import.cli import set_up_training_mode
 from pepys_import.core.store.data_store import DataStore
 from pepys_import.utils.data_store_utils import is_schema_created
@@ -100,7 +100,7 @@ def run_shell(path, training=False, data_store=None, db=None, viewer=False):
                         )
                     )
                     return
-                ViewDataShell(data_store, viewer=True).cmdloop()
+                ViewerShell(data_store, path).cmdloop()
         else:
             with handle_database_errors():
                 AdminShell(data_store, path).cmdloop()

--- a/pepys_admin/view_data_cli.py
+++ b/pepys_admin/view_data_cli.py
@@ -51,17 +51,13 @@ class ViewDataShell(BaseShell):
         self.viewer = viewer
 
         if viewer:
-            self.prompt = "(pepys-viewer) "
-            self.choices = self.choices.replace("(.) Back", "(.) Exit")
+            self.prompt = "(pepys-viewer) (view) "
         else:
             self.prompt = "(pepys-admin) (view) "
 
     def do_cancel(self):
         """Returns to the previous menu"""
-        if self.viewer:
-            print("Thank you for using Pepys Viewer")
-        else:
-            print("Returning to the previous menu...")
+        print("Returning to the previous menu...")
 
     def _get_table_names(self):
         """Gets the table names using SQL Alchemy's inspect db functionality."""

--- a/pepys_admin/viewer_cli.py
+++ b/pepys_admin/viewer_cli.py
@@ -1,0 +1,31 @@
+import os
+
+from pepys_admin.admin_cli import AdminShell
+
+DIR_PATH = os.path.dirname(os.path.abspath(__file__))
+
+
+class ViewerShell(AdminShell):
+    """The ViewerShell is a limited version of the AdminShell. It inherits from AdminShell so we don't
+    have to re-implement each function."""
+
+    choices = """(1) Status
+(2) View Data
+(3) View Docs
+(4) View dashboard
+(.) Exit
+"""
+    prompt = "(pepys-viewer) "
+
+    def __init__(self, data_store, csv_path=DIR_PATH):
+        super(ViewerShell, self).__init__(data_store, csv_path)
+        self.viewer = True
+        self.data_store = data_store
+        self.csv_path = csv_path
+        self.aliases = {
+            ".": self.do_exit,
+            "1": self.do_status,
+            "2": self.do_view_data,
+            "3": self.do_view_docs,
+            "4": self.do_view_dashboard,
+        }

--- a/tests/test_admin_cli.py
+++ b/tests/test_admin_cli.py
@@ -1746,8 +1746,8 @@ def test_viewer_mode_blank_db(patched_print):
     assert "Database schema does not exist: tables cannot be viewed" in output
 
 
-@patch("pepys_admin.cli.ViewDataShell")
-def test_viewer_mode_valid_db(patched_vds):
+@patch("pepys_admin.cli.ViewerShell")
+def test_viewer_mode_valid_db(patched_vs):
     if os.path.exists("created_db.db"):
         os.remove("created_db.db")
 
@@ -1756,7 +1756,7 @@ def test_viewer_mode_valid_db(patched_vds):
 
     run_shell(path=".", db="created_db.db", training=False, viewer=True)
 
-    patched_vds.assert_called_with(ANY, viewer=True)
+    patched_vs.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🧰 Issue
Fix #881 

## 🚀 Overview: 
Extend the Pepys Viewer app to offer more options. We now offer Status, View Data, View Docs and View dashboard.

## 🔗 Link to preview (or screenshot, if relevant)
![image](https://user-images.githubusercontent.com/296686/117636605-e3bdf100-b178-11eb-8b67-83a0665bc37a.png)

## 🤔 Reason: 
Allow users with only access to Pepys Viewer to run other actions like viewing the dashboard.

## 🔨Work carried out:

- [x] Create a new shell class for the Viewer, with only access to the options that are view-only
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.