### PR TITLE
Add ConfigOptions table to the whitelist of tables to be able to be viewed in the GUI

### DIFF
--- a/pepys_admin/maintenance/gui.py
+++ b/pepys_admin/maintenance/gui.py
@@ -152,6 +152,7 @@ class MaintenanceGUI:
             "Serials",
             "WargameParticipants",
             "SerialParticipants",
+            "ConfigOptions",
         ]
         measurement_tables = sorted(
             [mc.__tablename__ for mc in self.data_store.meta_classes[TableTypes.MEASUREMENT]]


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
Add the ConfigOptions table to the list of tables that can be viewed/edited in the Maintenance GUI.

## 🔗 Link to preview (or screenshot, if relevant)
![image](https://user-images.githubusercontent.com/296686/117654873-41106d00-b18e-11eb-9af9-2dfaf1e5e830.png)

## 🤔 Reason: 
Allow the users to edit config values like the Message of the Day.

## 🔨Work carried out:

- [x] Add ConfigOptions to the list of metadata tables that can be viewed/edited in the GUI
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
We use a whitelist of metadata tables that can be viewed in the GUI, as we don't want to include metadata tables that we aren't using yet (eg. LogsHoldings and others).
