### PR TITLE
[wip] Start using ConfigOptions table in timeline

### DIFF
--- a/pepys_timeline/api.py
+++ b/pepys_timeline/api.py
@@ -1,6 +1,10 @@
-from flask import Blueprint, current_app, render_template, request
+from flask import Blueprint, render_template, request
 
-from pepys_timeline.db import get_dashboard_metadata, get_dashboard_stats
+from pepys_timeline.db import (
+    get_config_options,
+    get_dashboard_metadata,
+    get_dashboard_stats,
+)
 
 api = Blueprint("api", __name__, url_prefix="")
 
@@ -14,7 +18,7 @@ def index():
 
 @api.route("/config")
 def config():
-    return {"frequency_secs": current_app.config["UPDATE_FREQUENCY"]}
+    return {"config_options": get_config_options()}
 
 
 @api.route("/dashboard_metadata")

--- a/pepys_timeline/config.py
+++ b/pepys_timeline/config.py
@@ -1,6 +1,5 @@
 import os
 
-UPDATE_FREQUENCY = 60
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 STATIC_DIR = os.path.join(ROOT_DIR, "static")

--- a/pepys_timeline/db.py
+++ b/pepys_timeline/db.py
@@ -5,7 +5,11 @@ import psycopg2
 from psycopg2.extras import RealDictCursor
 
 import config
-from pepys_timeline.queries import DASHBOARD_METADATA_QUERY, DASHBOARD_STATS_QUERY
+from pepys_timeline.queries import (
+    CONFIG_OPTIONS_QUERY,
+    DASHBOARD_METADATA_QUERY,
+    DASHBOARD_STATS_QUERY
+)
 
 
 def get_db_conn_kwargs():
@@ -17,6 +21,15 @@ def get_db_conn_kwargs():
         "password": config.DB_PASSWORD,
     }
     return db_params
+
+
+def get_config_options():
+    db_conn_kwargs = get_db_conn_kwargs()
+    with psycopg2.connect(**db_conn_kwargs) as conn:
+        with conn.cursor(cursor_factory=RealDictCursor) as curs:
+            curs.execute(CONFIG_OPTIONS_QUERY)
+            config_options = curs.fetchall()
+    return config_options
 
 
 def get_dashboard_metadata(from_date: str, to_date: str):

--- a/pepys_timeline/queries.py
+++ b/pepys_timeline/queries.py
@@ -1,2 +1,3 @@
+CONFIG_OPTIONS_QUERY = """select * from pepys."ConfigOptions";"""
 DASHBOARD_METADATA_QUERY = "select * from pepys.dashboard_metadata(%s, %s);"
 DASHBOARD_STATS_QUERY = "select * from pepys.dashboard_stats(%s, %s);"

--- a/pepys_timeline/static/js/src/pepys.js
+++ b/pepys_timeline/static/js/src/pepys.js
@@ -97,7 +97,7 @@ function startDatetimeClock() {
 }
 
 function updateCountdownProgress(seconds) {
-  const period = config.frequency_secs;
+  const period = config.TimelineRefreshSecs;
   const timePct = period !== 0 ? seconds/period : 0;
   const total = Math.PI * (2 * progress.r.baseVal.value);
   const progressPct = (1 - timePct) * total;
@@ -105,8 +105,8 @@ function updateCountdownProgress(seconds) {
 }
 
 function resetCountdown() {
-  countdownNumberEl.textContent = config.frequency_secs;
-  updateCountdownProgress(config.frequency_secs);
+  countdownNumberEl.textContent = config.TimelineRefreshSecs;
+  updateCountdownProgress(config.TimelineRefreshSecs);
 }
 
 function onTimerStarted(event) {
@@ -201,13 +201,13 @@ function fetchConfig() {
     fetch("/config")
         .then(response => response.json())
         .then(response => {
-            const { frequency_secs } = response;
-            config = response;
+            const { config_options } = response;
+            config = Object.fromEntries(config_options.map(o => ([o.name, o.value])));
 
             fetchSerialsMeta();
             setMessageOfTheDay();
 
-            const timerConfig = getTimerConfig(frequency_secs);
+            const timerConfig = getTimerConfig(config.TimelineRefreshSecs);
             timer.start(timerConfig);
         })
         .catch(err => console.error(err));


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `#1`)] 
     [Please use `fixes` if it fully resolves an issue (e.g. `fixes #321`)]
-->
Fixes #884 

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->
Previous PR for the same issue introduced the message of the day block with a placeholder message. In this PR, we start using the `pepys."ConfigOptions"` table to get the real message and display it.

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->
Previous PR was only able to display the placeholder message of the day.

## 🔨Work carried out:

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->

- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->

## Confirmations

- [ ] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [ ] I have extended/updated the documentation in `\docs` folder
- [ ] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [ ] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.