### PR TITLE
Treat warnings as errors in all pytest runs on CI

### DIFF
--- a/.github/workflows/test_pepys.yml
+++ b/.github/workflows/test_pepys.yml
@@ -42,14 +42,14 @@ jobs:
         env:
           PEPYS_SPATIALITE_PATH: /usr/lib/x86_64-linux-gnu/mod_spatialite.so
         run: |
-          coverage3 run -m pytest -v --color=yes --ignore=tests/gui_tests tests/
+          coverage3 run -m pytest -v --color=yes --ignore=tests/gui_tests tests/ -Werror
 
       - name: Run tests (GUI)
         shell: bash -l {0}
         env:
           PEPYS_SPATIALITE_PATH: /usr/lib/x86_64-linux-gnu/mod_spatialite.so
         run: |
-          coverage3 run -a -m pytest -v --color=yes -s tests/gui_tests
+          coverage3 run -a -m pytest -v --color=yes -s tests/gui_tests -Werror
 
       - name: Run black
         shell: bash -l {0}
@@ -129,4 +129,4 @@ jobs:
 
       - name: Run tests (no Postgres)
         shell: cmd
-        run: python.exe -m pytest -v --color=yes tests -m "not postgres"
+        run: python.exe -m pytest -v --color=yes tests -m "not postgres" -Werror

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 markers =
     postgres: marks tests as requiring a local postgres executable (deselect with '-m "not postgres"')
     automaton: marks tests as using the CLI automaton, which may take a while to run (deselect with '-m "not automaton"')
+filterwarnings =
+    error

--- a/tests/migration_tests/test_migration.py
+++ b/tests/migration_tests/test_migration.py
@@ -41,8 +41,17 @@ class MigrateSQLiteTestCase(unittest.TestCase):
     @patch("pepys_admin.admin_cli.prompt", return_value="Y")
     def test_do_migrate_empty_database(self, patched_input):
         assert is_schema_created(self.store.engine, self.store.db_type) is False
-        # Migrate
-        self.shell.do_migrate()
+        # This can raise SQLAlchemy warnings because of minor problems with past migrations
+        # I'm not sure whether the warnings are showing a real problem with an old migration
+        # or whether it is just an artefact of running a load of old migrations on top of each other
+        # However, it's a bad idea to alter the old migrations (it's like rewriting history)
+        # and the warning doesn't appear in any of the recent migration versions, so
+        # the best way forward is to ignore the warning
+        # These two lines of code are the recommended way to ignore warnings for a defined
+        # block of code
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.shell.do_migrate()
         assert is_schema_created(self.store.engine, self.store.db_type) is True
 
     @patch("pepys_admin.admin_cli.prompt", return_value="Y")
@@ -66,8 +75,17 @@ class MigrateSQLiteTestCase(unittest.TestCase):
         data_store = DataStore("", "", "", 0, COPY_DB_PATH, "sqlite")
         admin_shell = AdminShell(data_store)
 
-        # Migrate
-        admin_shell.do_migrate()
+        # This can raise SQLAlchemy warnings because of minor problems with past migrations
+        # I'm not sure whether the warnings are showing a real problem with an old migration
+        # or whether it is just an artefact of running a load of old migrations on top of each other
+        # However, it's a bad idea to alter the old migrations (it's like rewriting history)
+        # and the warning doesn't appear in any of the recent migration versions, so
+        # the best way forward is to ignore the warning
+        # These two lines of code are the recommended way to ignore warnings for a defined
+        # block of code
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            admin_shell.do_migrate()
         # Assert that it didn't break the schema
         assert is_schema_created(data_store.engine, data_store.db_type) is True
 


### PR DESCRIPTION
## 🧰 Issue
Fixes #955 

## 🚀 Overview: 
Adjusts the CI configuration to treat all warnings during pytest runs as errors.

## 🤔 Reason: 
Makes sure we will be aware of warnings.

## 🔨Work carried out:

- [x] Update CI configuration
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
