### PR TITLE
Fix display of build timestamp in Changes table

### DIFF
--- a/pepys_import/file/file_processor.py
+++ b/pepys_import/file/file_processor.py
@@ -254,7 +254,7 @@ class FileProcessor:
             reason = f"Importing '{basename}' using Pepys {__version__}"
             # ok, let these importers handle the file
             if __build_timestamp__ is not None:
-                reason += ", built on {__build_timestamp__}"
+                reason += f", built on {__build_timestamp__}"
 
             change = data_store.add_to_changes(user=USER, modified=datetime.utcnow(), reason=reason)
             privacy = None


### PR DESCRIPTION
## 🧰 Issue
#959 

## 🚀 Overview: 
Fixes display of build timestamp in the Changes table after an import. A format-string specifier (`f`) was missing, causing the name of the variable to be output rather than the contents.

## 🤔 Reason: 
Fix bug

## 🔨Work carried out:

- [x] Fix format string
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
