### PR TITLE
Disabling old versions of Pepys from connection to database

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,7 +31,7 @@ if not config.has_section("database"):
 if not config.has_option("database", "database_type"):
     # Config file is likely an older version
     print(
-        "Config file contains incorrect variable names. Please update your configuration to the correct format."
+        "Config file contains variable names used in legacy versions of Pepys that provided insufficient support for database migration. \n Please contact your system administrator to discuss renaming db_xxx to database_xxx."
     )
     sys.exit(1)
 

--- a/config.py
+++ b/config.py
@@ -28,12 +28,12 @@ if not config.has_section("database"):
     sys.exit(1)
 
 # Fetch database section
-DB_USERNAME = config.get("database", "db_username", fallback="")
-DB_PASSWORD = config.get("database", "db_password", fallback="")
-DB_HOST = config.get("database", "db_host", fallback="")
-DB_PORT = config.getint("database", "db_port", fallback=0)
-DB_NAME = config.get("database", "db_name")
-DB_TYPE = config.get("database", "db_type")
+DB_USERNAME = config.get("database", "database_username", fallback="")
+DB_PASSWORD = config.get("database", "database_password", fallback="")
+DB_HOST = config.get("database", "database_host", fallback="")
+DB_PORT = config.getint("database", "database_port", fallback=0)
+DB_NAME = config.get("database", "database_name")
+DB_TYPE = config.get("database", "database_type")
 
 # Process username and password if necessary
 if DB_USERNAME.startswith("_") and DB_USERNAME.endswith("_"):

--- a/config.py
+++ b/config.py
@@ -27,6 +27,14 @@ if not config.has_section("database"):
     print(f"Couldn't find 'database' section in '{CONFIG_FILE_PATH}'!")
     sys.exit(1)
 
+# Error if database type is not found
+if not config.has_option("database", "database_type"):
+    # Config file is likely an older version
+    print(
+        "Config file contains incorrect variable names. Please update your configuration to the correct format."
+    )
+    sys.exit(1)
+
 # Fetch database section
 DB_USERNAME = config.get("database", "database_username", fallback="")
 DB_PASSWORD = config.get("database", "database_password", fallback="")

--- a/default_config.ini
+++ b/default_config.ini
@@ -1,10 +1,10 @@
 [database]
-db_username =
-db_password =
-db_host =
-db_port = 0
-db_name = pepys_test.sqlite
-db_type = sqlite
+database_username =
+database_password =
+database_host =
+database_port = 0
+database_name = pepys_test.sqlite
+database_type = sqlite
 [archive]
 user = pepys_admin
 password = 123456

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -32,12 +32,12 @@ Configuration file variables
 These settings control how pepys-import connects to the database. The specific
 variables are:
 
- - :code:`db_username`: Username used to connect to the database server (default: :code:`postgres`). Only used for PostgreSQL connections. Can be encrypted.
- - :code:`db_password`: Password used to connect to the database server (default: :code:`postgres`). Only used for PostgreSQL connections. Can be encrypted.
- - :code:`db_host`: Host (name or IP address) on which the database server is running (default: :code:`localhost`). Only used for PostgreSQL connections.
- - :code:`db_port`: Port on which the database server is accepting connections (default: :code:`5432`). Only used for PostgreSQL connections.
- - :code:`db_name`: Name of the database on the server (for PostgreSQL) or name of the database file to be used for SQLite (default: :code:`pepys`). Can be set to :code:`:memory:` for an in-memory SQLite database.
- - :code:`db_type`: Type of database to use: must be set to either :code:`sqlite` or :code:`postgres` (default: :code:`postgres`)
+ - :code:`database_username`: Username used to connect to the database server (default: :code:`postgres`). Only used for PostgreSQL connections. Can be encrypted.
+ - :code:`database_password`: Password used to connect to the database server (default: :code:`postgres`). Only used for PostgreSQL connections. Can be encrypted.
+ - :code:`database_host`: Host (name or IP address) on which the database server is running (default: :code:`localhost`). Only used for PostgreSQL connections.
+ - :code:`database_port`: Port on which the database server is accepting connections (default: :code:`5432`). Only used for PostgreSQL connections.
+ - :code:`database_name`: Name of the database on the server (for PostgreSQL) or name of the database file to be used for SQLite (default: :code:`pepys`). Can be set to :code:`:memory:` for an in-memory SQLite database.
+ - :code:`database_type`: Type of database to use: must be set to either :code:`sqlite` or :code:`postgres` (default: :code:`postgres`)
 
 :code:`[archive]` section
 ##########################

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -33,7 +33,7 @@ DIR_PATH = os.path.dirname(__file__)
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-db_type = config.attributes.get("db_type", DB_TYPE)
+db_type = config.attributes.get("database_type", DB_TYPE)
 
 version_path = os.path.join(DIR_PATH, "versions")
 if db_type == "postgres":

--- a/pepys_admin/admin_cli.py
+++ b/pepys_admin/admin_cli.py
@@ -69,7 +69,7 @@ class AdminShell(BaseShell):
         self.cfg = Config(os.path.join(ROOT_DIRECTORY, "alembic.ini"))
         script_location = os.path.join(ROOT_DIRECTORY, "migrations")
         self.cfg.set_main_option("script_location", script_location)
-        self.cfg.attributes["db_type"] = data_store.db_type
+        self.cfg.attributes["database_type"] = data_store.db_type
         self.cfg.attributes["connection"] = data_store.engine
 
     def do_view_dashboard(self):

--- a/pepys_import/cli.py
+++ b/pepys_import/cli.py
@@ -196,12 +196,12 @@ def set_up_training_mode():
     archive_folder = os.path.join(training_data_folder, "output")
 
     config_contents = f"""[database]
-db_username =
-db_password =
-db_host =
-db_port = 0
-db_name = {db_path}
-db_type = sqlite
+database_username =
+database_password =
+database_host =
+database_port = 0
+database_name = {db_path}
+database_type = sqlite
 
 [archive]
 path = {archive_folder}"""

--- a/tests/config_file_tests/example_config/config_for_do_migrate.ini
+++ b/tests/config_file_tests/example_config/config_for_do_migrate.ini
@@ -1,10 +1,10 @@
 [database]
-db_username =
-db_password =
-db_host =
-db_port = 0
-db_name = new_db.db
-db_type = sqlite
+database_username =
+database_password =
+database_host =
+database_port = 0
+database_name = new_db.db
+database_type = sqlite
 [archive]
 user = pepys_admin
 password = 123456

--- a/tests/config_file_tests/example_config/config_older_version.ini
+++ b/tests/config_file_tests/example_config/config_older_version.ini
@@ -4,7 +4,7 @@ database_password = _123456_
 database_host = localhost
 database_port = 5432
 database_name = test
-database_type = postgres
+db_type = postgres
 [archive]
 user = _user_
 password = _password_

--- a/tests/config_file_tests/test_config_file.py
+++ b/tests/config_file_tests/test_config_file.py
@@ -78,7 +78,7 @@ class ConfigVariablesTestCase(unittest.TestCase):
             reload(config)
         output = temp_output.getvalue()
         assert (
-            "Config file contains incorrect variable names. Please update your configuration to the correct format."
+            "Config file contains variable names used in legacy versions of Pepys that provided insufficient support for database migration. \n Please contact your system administrator to discuss renaming db_xxx to database_xxx."
             in output
         )
 

--- a/tests/config_file_tests/test_config_file.py
+++ b/tests/config_file_tests/test_config_file.py
@@ -20,6 +20,7 @@ BAD_IMPORTER_PATH = os.path.join(DIRECTORY_PATH, "bad_path")
 OUTPUT_PATH = os.path.join(DIRECTORY_PATH, "output")
 CONFIG_FILE_PATH = os.path.join(DIRECTORY_PATH, "example_config", "config.ini")
 CONFIG_FILE_PATH_2 = os.path.join(DIRECTORY_PATH, "example_config", "config_without_database.ini")
+CONFIG_FILE_PATH_3 = os.path.join(DIRECTORY_PATH, "example_config", "config_older_version.ini")
 BASIC_PARSERS_PATH = os.path.join(DIRECTORY_PATH, "basic_tests")
 ENHANCED_PARSERS_PATH = os.path.join(DIRECTORY_PATH, "enhanced_tests")
 DATA_PATH = os.path.join(DIRECTORY_PATH, "..", "sample_data")
@@ -68,6 +69,18 @@ class ConfigVariablesTestCase(unittest.TestCase):
             reload(config)
         output = temp_output.getvalue()
         assert "Couldn't find 'database' section in" in output
+
+    @patch.dict(os.environ, {"PEPYS_CONFIG_FILE": CONFIG_FILE_PATH_3})
+    def test_with_older_config_file(self):
+        # Older configuration files should throw an error and exit.
+        temp_output = StringIO()
+        with redirect_stdout(temp_output), pytest.raises(SystemExit):
+            reload(config)
+        output = temp_output.getvalue()
+        assert (
+            "Config file contains incorrect variable names. Please update your configuration to the correct format."
+            in output
+        )
 
     @patch.dict(os.environ, {"PEPYS_CONFIG_FILE_USER": CONFIG_FILE_PATH})
     def test_config_file_user_variable(self):

--- a/tests/config_file_tests/test_config_file.py
+++ b/tests/config_file_tests/test_config_file.py
@@ -72,7 +72,7 @@ class ConfigVariablesTestCase(unittest.TestCase):
 
     @patch.dict(os.environ, {"PEPYS_CONFIG_FILE": CONFIG_FILE_PATH_3})
     def test_with_older_config_file(self):
-        # Older configuration files should throw an error and exit.
+        # pylint: disable=no-self-use
         temp_output = StringIO()
         with redirect_stdout(temp_output), pytest.raises(SystemExit):
             reload(config)


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `#1`)] 
     [Please use `fixes` if it fully resolves an issue (e.g. `fixes #321`)]
-->
Fixes #964 

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->
Changes to `default_config.ini` and `config.py` variables to now be _database_ rather than _db_. 
Older versions should no longer connect as variable names will not match and will instead throw an error.


## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->
Preventative measure to stop older versions of Pepys from interacting with current databases.


- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [ ] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [ ] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

