### PR TITLE
Fix GUI selection status update bug

### DIFF
--- a/pepys_admin/maintenance/gui.py
+++ b/pepys_admin/maintenance/gui.py
@@ -437,6 +437,11 @@ class MaintenanceGUI:
             # and the user might type something correct soon anyway
             pass
 
+        # Force the list of currently selected rows to be empty here
+        # This is also done in CheckboxTable itself, but because of the async nature of the code
+        # it isn't always run in the right order. This forces this to be empty before updating
+        # the selected items label
+        self.preview_table.current_values = []
         self.update_selected_items_label()
 
     def get_table_data(self):


### PR DESCRIPTION
## 🧰 Issue
Fixes #980.

## 🚀 Overview: 
Fixes a bug where the selection status message at the bottom of the preview table didn't update properly if a new table was selected (see issue for full description).

## 🤔 Reason: 
Fix bug

## 🔨Work carried out:

- [x] Add an explicit call to unselect everything, to work around a mis-ordering bug caused by async stuff
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
