### PR TITLE
Fix Codacy errors by giving Prospector configuration

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -1,0 +1,5 @@
+strictness: medium
+doc-warnings: false
+test-warnings: false
+autodetect: true
+member-warnings: false


### PR DESCRIPTION
## 🧰 Issue
Fixes #978
Fixes #974

## 🚀 Overview: 
Configures the Prospector tool (as used by Codacy) to remove unhelpful checks which lead to conflicting errors. By default it seems Codacy does not use the 'default' Prospector config, so we have copied it to a `.prospector.yml` file.

## 🤔 Reason: 
Get rid of conflicting and unhelpful errors.

## 🔨Work carried out:

- [x] Added prospector config
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
This is hard to test as Codacy only gives warnings for code lines/files that have changed. I suggest we assume this works and merge it, and then test it as part of the next set of PRs that we do (eg. the Export to CSV PR).