### PR TITLE
Fix View Data CLI bugs and add more tests

### DIFF
--- a/pepys_admin/view_data_cli.py
+++ b/pepys_admin/view_data_cli.py
@@ -139,6 +139,8 @@ class ViewDataShell(BaseShell):
                 headers.append(column.key)
         # Get the association proxy attributes for this table
         associated_attributes, _ = get_assoc_proxy_names_and_objects(table_cls)
+        if "privacy_name" in associated_attributes:
+            associated_attributes.remove("privacy_name")
 
         header_attributes = [getattr(table_cls, header_name) for header_name in headers]
         # Fetch first rows up to MAX_ROWS_DISPLAYED, create a table from these rows

--- a/pepys_admin/view_data_cli.py
+++ b/pepys_admin/view_data_cli.py
@@ -7,12 +7,12 @@ from prompt_toolkit.lexers import PygmentsLexer
 from pygments.lexers.sql import SqlLexer
 from sqlalchemy import inspect
 from sqlalchemy.exc import InvalidRequestError, OperationalError, ProgrammingError
-from sqlalchemy.ext.associationproxy import AssociationProxy
 from sqlalchemy.orm import RelationshipProperty, class_mapper, load_only
 from sqlalchemy.sql.expression import text
 from tabulate import tabulate
 
 from pepys_admin.base_cli import BaseShell
+from pepys_admin.maintenance.column_data import get_assoc_proxy_names_and_objects
 from pepys_admin.utils import get_default_export_folder
 from pepys_import.core.store import constants
 from pepys_import.utils.table_name_utils import table_name_to_class_name
@@ -77,6 +77,9 @@ class ViewDataShell(BaseShell):
                 and not name.startswith("geometry")
                 and not name.startswith("views")
                 and not name.startswith("sql")
+                and not name.startswith("KNN")
+                and not name.startswith("ElementaryGeometries")
+                and not name.startswith("data_licenses")
                 and not name.lower().startswith("spatial")
             ]
         # Sort table names in alphabetical order
@@ -87,13 +90,21 @@ class ViewDataShell(BaseShell):
         """Asks user to select a table name. Converts table name to class name,
         fetches the objects up to the number of MAX_ROWS_DISPLAYED, and prints them in table format.
         """
-        headers = list()
-        associated_attributes = list()
         table_names = self._get_table_names()
         message = "Select a table >"
         selected_table = iterfzf(table_names, prompt=message)
         if selected_table is None:
             return
+
+        text = self.generate_view_table_text(selected_table)
+        print(text)
+
+    def generate_view_table_text(self, selected_table):
+        headers = []
+        associated_attributes = []
+
+        output_text = ""
+
         # Table names are plural in the database, therefore make it singular
         table = table_name_to_class_name(selected_table)
 
@@ -104,16 +115,15 @@ class ViewDataShell(BaseShell):
                 else:
                     result = connection.execute(text("SELECT * FROM alembic_version;"))
                     result = result.fetchall()
-                res = "Alembic Version\n"
-                res += tabulate(
+                output_text += "Alembic Version\n"
+                output_text += tabulate(
                     [[str(column) for column in row] for row in result],
                     headers=["version_number"],
                     tablefmt="grid",
                     floatfmt=".3f",
                 )
-                res += "\n"
-                print(res)
-            return
+                output_text += "\n"
+                return output_text
         # Find the class
         table_cls = getattr(self.data_store.db_classes, table)
         assert table_cls.__tablename__ == selected_table, "Couldn't find table!"
@@ -127,12 +137,9 @@ class ViewDataShell(BaseShell):
             # Take only if column is not a foreign key and it is not deferred
             if column_property.deferred is False and not column.foreign_keys:
                 headers.append(column.key)
-        # In order to find and extract association_proxy attributes, iterate over all_orm_descriptors
-        for descriptor in mapper.all_orm_descriptors:
-            if isinstance(descriptor, AssociationProxy):
-                name = f"{descriptor.target_collection}_{descriptor.value_attr}"
-                if name != "privacy_name":
-                    associated_attributes.append(name)
+        # Get the association proxy attributes for this table
+        associated_attributes, _ = get_assoc_proxy_names_and_objects(table_cls)
+
         header_attributes = [getattr(table_cls, header_name) for header_name in headers]
         # Fetch first rows up to MAX_ROWS_DISPLAYED, create a table from these rows
         with self.data_store.session_scope():
@@ -145,15 +152,18 @@ class ViewDataShell(BaseShell):
             headers.extend(associated_attributes)
             # Sort headers
             headers.sort()
-            res = f"{selected_table}\n"
-            res += tabulate(
-                [[str(getattr(row, column)) for column in headers] for row in values],
+
+            table_data = [[str(getattr(row, column)) for column in headers] for row in values]
+
+            output_text += f"{selected_table}\n"
+            output_text += tabulate(
+                table_data,
                 headers=headers,
                 tablefmt="grid",
                 floatfmt=".3f",
             )
-        res += "\n"
-        print(res)
+        output_text += "\n"
+        return output_text
 
     def do_output_table_to_csv(self):
         """Asks user to select a table name. Fetches all objects, and exports them to a CSV file."""

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -309,7 +309,7 @@ class WargameMixin:
         )
 
     @declared_attr
-    def participant_platform_name(self):
+    def participants_platform_name(self):
         return association_proxy("participants", "platform_name")
 
     @declared_attr
@@ -393,7 +393,7 @@ class SerialMixin:
         return association_proxy("wargame", "name")
 
     @declared_attr
-    def participant_platform_name(self):
+    def participants_platform_name(self):
         return association_proxy("participants", "platform_name")
 
     @declared_attr

--- a/tests/gui_tests/test_column_data.py
+++ b/tests/gui_tests/test_column_data.py
@@ -736,10 +736,10 @@ def test_column_data_wargame():
             "type": "string",
             "values": [],
         },
-        "participant platform name": {
+        "participants platform name": {
             "required": True,
             "sqlalchemy_type": "assoc_proxy",
-            "system_name": "participant_platform_name",
+            "system_name": "participants_platform_name",
             "type": "string",
             "values": [],
         },

--- a/tests/test_view_data_cli.py
+++ b/tests/test_view_data_cli.py
@@ -399,5 +399,21 @@ def test_check_query_only_select():
     )
 
 
+def test_view_all_tables():
+    store = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+    store.initialise()
+    with store.session_scope():
+        store.populate_reference()
+        store.populate_metadata()
+
+    shell = ViewDataShell(store)
+    for table_name in shell._get_table_names():
+        print(f"Running test for {table_name}:")
+        # Generate the output text for this table - we just want to make sure this works without
+        # giving any errors
+        output = shell.generate_view_table_text(table_name)
+        assert output != ""
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 🧰 Issue
Fixes #963 

## 🚀 Overview: 
Fixed bug where viewing some tables in the View Data CLI led to an attribute error. Refactored a bit, and added more tests to ensure that all tables can be viewed.

## 🤔 Reason: 
Fix bug and improve testing

## 🔨Work carried out:

- [x] Fix View Data CLI to get association proxies correctly, and thus not generate attribute errors.
- [x] Fix names of some association proxies to better reflect normal naming convention
- [x] Refactor function to view table to extract code that generates text
- [x] Add test to check that text can be generated for each table
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
The View Data CLI code that dealt with association proxies could be replaced with a call to one of the functions written for the GUI - the GUI didn't exist when this CLI code was first written, and so we were 'doing it the hard way'. This way is much more robust, and shouldn't lead to errors. We also add tests to ensure that all tables can be viewed without errors.

