### PR TITLE
Add extra test for check_migration_version

### DIFF
--- a/tests/test_datastore_utils.py
+++ b/tests/test_datastore_utils.py
@@ -200,6 +200,23 @@ def test_check_migration_version_incorrect_length_null_value():
     assert exit_exception_e.value.code == 1
 
 
+def test_check_migration_version_incorrect_n_cols():
+    ds = DataStore("", "", "", 0, ":memory:", db_type="sqlite")
+    revisions = ["version_id", "test_version_id"]
+
+    with ds.engine.begin() as connection:
+        connection.execute(text("CREATE TABLE alembic_version (col1, col2, col3);"))
+        connection.execute(text("INSERT INTO alembic_version VALUES ('', '', '');"))
+
+    with pytest.raises(SystemExit) as exit_exception_e:
+        temp_output = StringIO()
+        with redirect_stdout(temp_output):
+            ds.check_migration_version(revisions)
+    output = temp_output.getvalue()
+    assert "ERROR: Retrieved version contents from database is incorrect length." in output
+    assert exit_exception_e.value.code == 1
+
+
 def test_check_migration_version_no_table_contents():
     # Create a new alembic version database - function should pass
     ds = DataStore("", "", "", 0, ":memory:", db_type="sqlite")


### PR DESCRIPTION
## 🧰 Issue
Fixes #966 

## 🚀 Overview: 
Added extra test for check_migration_version to improve coverage.

## 🤔 Reason: 
Improve test coverage

## 🔨Work carried out:

- [x] Add test
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
The only bit of the function that wasn't tested was dealing with an incorrect number of columns returned from the database. This is unlikely to happen in real-life, but can be simulated by creating the alembic_version table with more than one column. That's what this test does.