### PR TITLE
Increase benchmark time limits

### DIFF
--- a/tests/benchmarks/test_highlighter_benchmark.py
+++ b/tests/benchmarks/test_highlighter_benchmark.py
@@ -134,7 +134,7 @@ def run_highlighter_on_whole_file():
 def test_highlighter_on_whole_file_benchmark(benchmark):
     benchmark(run_highlighter_on_whole_file)
 
-    TIME_THRESHOLD = 10
+    TIME_THRESHOLD = 11
 
     if running_on_ci():
         if benchmark.stats.stats.mean > TIME_THRESHOLD:
@@ -155,7 +155,7 @@ def run_fill_char_array():
 def test_highlighter_fill_char_array_benchmark(benchmark):
     benchmark(run_fill_char_array)
 
-    TIME_THRESHOLD = 6
+    TIME_THRESHOLD = 7
 
     if running_on_ci():
         if benchmark.stats.stats.mean > TIME_THRESHOLD:

--- a/tests/benchmarks/test_import_benchmark.py
+++ b/tests/benchmarks/test_import_benchmark.py
@@ -27,7 +27,7 @@ def test_single_rep_file_import_short(benchmark):
         file_path=os.path.join(FILE_DIR, "benchmark_data/rep_test1.rep"),
     )
 
-    TIME_THRESHOLD = 0.9
+    TIME_THRESHOLD = 1.1
 
     if running_on_ci():
         if benchmark.stats.stats.mean > TIME_THRESHOLD:


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
Increases the time limits for the benchmark tests, to stop spurious test failures when the benchmarks take slightly longer than allowed.

## 🤔 Reason: 
Stop unneeded test failures

## 🔨Work carried out:

- [x] Update benchmarks
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.