### PR TITLE
Fix branch names in deployment script

### DIFF
--- a/create_deployment.ps1
+++ b/create_deployment.ps1
@@ -236,7 +236,8 @@ try {
         $gitbranch = git branch --show-current
     }
     
-    $output_filename = "pepys_import-$date_str-$gitbranch-$gitcommit.zip"
+    $output_filename = "pepys_import-$date_str-$gitbranch-$gitcommit.zip".Replace("/", "-")
+
     .\7zip\7za.exe a .\$output_filename .\* -xr!7zip/ -xr!"bin\distlib-0.3.0-py2.py3-none-any.whl"
 
     if ($LastExitCode -ne 0)


### PR DESCRIPTION
## 🧰 Issue
#1001 

## 🚀 Overview: 
Change the create deployment script to be able to deal with branch names with `/` in them, by replacing it with `-`.

## 🤔 Reason: 
So the deployment doesn't break when branches with `/` in them are used.

## 🔨Work carried out:

- [x] Update create deployment script
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.