### PR TITLE
Significantly improve speed of table summaries

### DIFF
--- a/pepys_import/core/store/table_summary.py
+++ b/pepys_import/core/store/table_summary.py
@@ -43,7 +43,9 @@ class TableSummary:
             if self.created_date == "-":
                 self.names = []
             else:
-                self.names = [a.name for a in self.session.query(self.table).all()]
+                self.names = [
+                    result[0] for result in self.session.query(getattr(self.table, "name")).all()
+                ]
 
 
 class TableSummarySet:


### PR DESCRIPTION
## 🧰 Issue
#1014 

## 🚀 Overview: 
Significantly improve the speed of the calculation of table summaries at the end of an import, by not retrieving the full objects for Platform/Sensor objects, and just querying the name instead. This saves doing all the joins and returning the full object, and in tests it sped up the process by 2-3x.

## 🤔 Reason: 
Speed

## 🔨Work carried out:

- [x] Change query to just query name, rather than whole object
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
This is a fairly 'obvious' error, so I've done a search in the codebase to see if I can find any other lines of code that are similar elsewhere. I couldn't find any, so I don't think we've got this problem anywhere else.
