### PR TITLE
Fix error when viewing Platform entry in GUI

### DIFF
--- a/pepys_admin/maintenance/column_data.py
+++ b/pepys_admin/maintenance/column_data.py
@@ -404,6 +404,12 @@ def convert_column_data_to_edit_data(column_data, set_percentage=None):
             # Don't allow to edit ID columns
             continue
 
+        if key == "wargame participations":
+            # Don't allow to edit wargame participations, as joining the data
+            # initially takes a long time, and slows everything down
+            # This can be edited in the Tasks GUI
+            continue
+
         if value["sqlalchemy_type"] == "relationship" and value["second_level"]:
             continue
 

--- a/pepys_admin/maintenance/gui.py
+++ b/pepys_admin/maintenance/gui.py
@@ -31,7 +31,7 @@ from prompt_toolkit.lexers.pygments import PygmentsLexer
 from prompt_toolkit.styles import Style
 from prompt_toolkit.widgets.base import Border, Label
 from pygments.lexers.sql import SqlLexer
-from sqlalchemy.orm import undefer
+from sqlalchemy.orm import joinedload, undefer
 
 from pepys_admin.maintenance.column_data import convert_column_data_to_edit_data, create_column_data
 from pepys_admin.maintenance.dialogs.add_dialog import AddDialog
@@ -414,9 +414,14 @@ class MaintenanceGUI:
 
                 count = query_obj.count()
 
-                # Get the first 100 results, while undefering all fields to make sure everything is
-                # available once it's been expunged (disconnected) from the database
-                results = query_obj.options(undefer("*")).limit(MAX_PREVIEW_TABLE_RESULTS).all()
+                # Get the first 100 results, while undefering all fields and loading all relationships
+                # with a join, to make sure everything is available once it's been expunged
+                # (disconnected) from the database
+                results = (
+                    query_obj.options(undefer("*"), joinedload("*"))
+                    .limit(MAX_PREVIEW_TABLE_RESULTS)
+                    .all()
+                )
 
                 if len(results) == 0:
                     self.preview_table_message.text = ""

--- a/pepys_admin/maintenance/gui.py
+++ b/pepys_admin/maintenance/gui.py
@@ -665,7 +665,7 @@ class MaintenanceGUI:
         async def coroutine():
             if len(self.preview_table.current_values) != 1:
                 await self.show_messagebox_async(
-                    "Error", "You must select exactly one entry before editing."
+                    "Error", "You must select exactly one entry before viewing."
                 )
                 return
 

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -493,7 +493,7 @@ class WargameParticipantMixin:
         return relationship(
             "Platform",
             lazy="joined",
-            backref=backref("participations", info={"skip_in_gui": True}),
+            backref=backref("participations", info={"skip_in_gui": True}, lazy="joined"),
         )
 
     @declared_attr

--- a/pepys_import/core/store/common_db.py
+++ b/pepys_import/core/store/common_db.py
@@ -493,7 +493,7 @@ class WargameParticipantMixin:
         return relationship(
             "Platform",
             lazy="joined",
-            backref=backref("participations", info={"skip_in_gui": True}, lazy="joined"),
+            backref=backref("participations", info={"skip_in_gui": True}),
         )
 
     @declared_attr


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
Fix bug where trying to view an entry from the Platforms table in the Maintenance GUI led to an error: `Exception Parent instance <Platform at 0x112b86c40> is not bound to a Session; lazy load operation of attribute 'participations' cannot proceed (Background on this error at: https://sqlalche.me/e/14/bhk3)`

## 🤔 Reason: 
Fix bug

## 🔨Work carried out:
- [x] Set up lazy-loading via joining on the backreference from WargameParticipants to Platforms, so that the `participants` attribute on the `Platform` class can be read without needing the object to still be in the session
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
