### PR TITLE
Don't produce -ve percentage

### DIFF
--- a/pepys_import/database/postgres_stored_procedures/dashboard_stats.sql
+++ b/pepys_import/database/postgres_stored_procedures/dashboard_stats.sql
@@ -116,7 +116,7 @@ participation_sans_activity as (
 		si.serial_id,
 		si.ser_idx
 	from
-		sensors_involved si
+		participating_platforms si
 	where
 		not exists (select 1
 					from 
@@ -253,7 +253,7 @@ participation_sans_gap as (
 		si.serial_id,
 		si.ser_idx
 	from
-		sensors_involved si
+		participating_platforms si
 	where
 		not exists (select 1
 					from 
@@ -288,7 +288,7 @@ act_with_same_part_and_gap_start as (
 				and cg.rowno = 1
 				and cg.start_time =  s.time
 			inner join
-		sensors_involved si
+		participating_platforms si
 				on si.serial_participant_start = cg.start_time
 				and si.platform_id = cg.platform_id
 				and si.serial_id = cg.serial_id
@@ -320,7 +320,7 @@ act_with_same_part_and_gap_end as (
 									cgrs1.platform_id = cg.platform_id)
 				and cg.end_time =  s.time
 			inner join
-		sensors_involved si
+		participating_platforms si
 				on si.serial_participant_end = cg.end_time
 				and si.platform_id = cg.platform_id
 				and si.serial_id = cg.serial_id


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `#1`)] 
     [Please use `fixes` if it fully resolves an issue (e.g. `fixes #321`)]
-->
Fixes #1019 

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->
A SQL mistake meant there were circumstances where a coverage end date could appear before the start, giving a `-100%` coverage.


## 🔗 Link to preview (or screenshot, if relevant)
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->

Before:
![image](https://user-images.githubusercontent.com/1108513/134012087-abcfb6f5-3a9c-4f86-be41-4f4bc8119d29.png)

After:
![image](https://user-images.githubusercontent.com/1108513/134365706-faad6b1f-d476-4530-ab6e-c9efae5224bb.png)

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->

## 🔨Work carried out:

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->

- [x] Tests updated.

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [ ] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

**Note:** Alembic revisions pending.
