### PR TITLE
Significantly speedup calculation of table summaries

### DIFF
--- a/pepys_import/core/store/table_summary.py
+++ b/pepys_import/core/store/table_summary.py
@@ -1,4 +1,3 @@
-from sqlalchemy.orm import undefer
 from tabulate import tabulate
 
 from pepys_import.core.store import constants
@@ -27,10 +26,7 @@ class TableSummary:
     def table_summary(self):
         number_of_rows = self.session.query(self.table).count()
         last_row = (
-            self.session.query(self.table)
-            .options(
-                undefer("*")
-            )  # Fetch all attributes to enforce to failing if there is any mismatch
+            self.session.query(self.table.created_date)
             .order_by(self.table.created_date.desc())
             .first()
         )

--- a/tests/test_import_cli.py
+++ b/tests/test_import_cli.py
@@ -163,34 +163,6 @@ class TestImportWithWrongTypeDBFieldPostgres(unittest.TestCase):
         except AttributeError:
             return
 
-    @patch("pepys_import.utils.error_handling.custom_print_formatted_text", side_effect=side_effect)
-    def test_import_with_wrong_type_db_field(self, patched_print):
-        conn = pg8000.connect(user="postgres", password="postgres", database="test", port=55527)
-        cursor = conn.cursor()
-        # Alter table to change heading column to be a timestamp
-        cursor.execute(
-            'ALTER TABLE pepys."States" ALTER COLUMN heading SET DATA TYPE character varying(150);'
-        )
-
-        conn.commit()
-        conn.close()
-
-        temp_output = StringIO()
-        with redirect_stdout(temp_output):
-            db_config = {
-                "name": "test",
-                "host": "localhost",
-                "username": "postgres",
-                "password": "postgres",
-                "port": 55527,
-                "type": "postgres",
-            }
-
-            process(path=DATA_PATH, archive=False, db=db_config, resolver="default")
-        output = temp_output.getvalue()
-
-        assert "ERROR: SQL error when communicating with database" in output
-
 
 @patch("pepys_import.cli.DefaultResolver")
 def test_process_resolver_specification_default(patched_default_resolver):


### PR DESCRIPTION
## 🧰 Issue
Fixes #1030 

## 🚀 Overview: 
Speed up calculation of table summaries at the beginning and end of an import by not retrieving the whole object from the database, but just retrieving the relevant fields. Tests show speedups of around 2x for metadata summaries, and 6.5x for measurement summaries - although I imagine these speed-ups will be higher for the users.

## 🤔 Reason: 
Speed up imports.

## 🔨Work carried out:

- [x] Just query the created_date field rather than the whole object
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-imxort.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.