### PR TITLE
Change Postgres tests to properly fail if testing server can't be started

### DIFF
--- a/tests/test_admin_cli.py
+++ b/tests/test_admin_cli.py
@@ -807,8 +807,7 @@ class TestAdminCLIWithMissingDBFieldPostgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -820,7 +819,7 @@ class TestAdminCLIWithMissingDBFieldPostgres(unittest.TestCase):
             )
             self.store.initialise()
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -284,8 +284,7 @@ class TestNotEmptyStringPostgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
 
         self.store = DataStore(
             db_name="test",

--- a/tests/test_data_store_api_postgis.py
+++ b/tests/test_data_store_api_postgis.py
@@ -37,8 +37,7 @@ class DataStoreCacheTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -53,8 +52,8 @@ class DataStoreCacheTestCase(TestCase):
                 self.change_id = self.store.add_to_changes(
                     "TEST", datetime.utcnow(), "TEST"
                 ).change_id
-        except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+        except Exception:
+            raise Exception("Testing postgres server could not be started/accessed")
 
     def tearDown(self) -> None:
         try:
@@ -258,8 +257,7 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -275,7 +273,7 @@ class LookUpDBAndAddToCacheTestCase(TestCase):
                     "TEST", datetime.utcnow(), "TEST"
                 ).change_id
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self) -> None:
         try:
@@ -406,8 +404,7 @@ class PlatformAndDatafileTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -430,7 +427,7 @@ class PlatformAndDatafileTestCase(TestCase):
                 ).name
                 self.privacy = self.store.add_to_privacies("test_privacy", 0, self.change_id).name
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self) -> None:
         try:
@@ -637,8 +634,7 @@ class DataStoreStatusTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -653,7 +649,7 @@ class DataStoreStatusTestCase(TestCase):
                 self.store.populate_reference(TEST_DATA_PATH)
                 self.store.populate_metadata(TEST_DATA_PATH)
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self) -> None:
         try:
@@ -718,8 +714,7 @@ class SensorTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -754,7 +749,7 @@ class SensorTestCase(TestCase):
                 )
                 self.store.session.expunge(self.platform)
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self) -> None:
         try:
@@ -831,8 +826,7 @@ class MeasurementsTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -879,7 +873,7 @@ class MeasurementsTestCase(TestCase):
                 self.store.session.expunge(self.file)
                 self.store.session.expunge(self.comment_type)
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
         class TestParser(Importer):
             def __init__(
@@ -1018,8 +1012,7 @@ class FirstConnectionTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
 
     def tearDown(self) -> None:
         try:

--- a/tests/test_data_store_clear_db.py
+++ b/tests/test_data_store_clear_db.py
@@ -20,7 +20,7 @@ class DataStoreClearContentsPostGISDBTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:
@@ -108,7 +108,7 @@ class DataStoreClearSchemaPostGISTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:

--- a/tests/test_data_store_clear_db.py
+++ b/tests/test_data_store_clear_db.py
@@ -8,6 +8,7 @@ from testing.postgresql import Postgresql
 from pepys_import.core.store.data_store import DataStore
 
 
+@pytest.mark.postgres
 class DataStoreClearContentsPostGISDBTestCase(TestCase):
     def setUp(self):
         self.store = None

--- a/tests/test_data_store_export_datafile.py
+++ b/tests/test_data_store_export_datafile.py
@@ -27,7 +27,7 @@ class DataStoreExportPostGISDBTestCase(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self) -> None:
         if os.path.exists(self.path):

--- a/tests/test_data_store_initialise.py
+++ b/tests/test_data_store_initialise.py
@@ -22,7 +22,7 @@ class DataStoreInitialisePostGISTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:

--- a/tests/test_data_store_populate.py
+++ b/tests/test_data_store_populate.py
@@ -156,8 +156,7 @@ class DataStorePopulatePostGISTestCase(TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -169,7 +168,7 @@ class DataStorePopulatePostGISTestCase(TestCase):
             )
             self.store.initialise()
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self) -> None:
         try:

--- a/tests/test_datastore_utils.py
+++ b/tests/test_datastore_utils.py
@@ -249,8 +249,7 @@ class TestCreateAlembicVersionTable_Postgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -262,7 +261,7 @@ class TestCreateAlembicVersionTable_Postgres(unittest.TestCase):
             )
             self.store.initialise()
         except Exception:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:
@@ -354,8 +353,7 @@ class TestCheckMigrationVersion_Postgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -367,7 +365,7 @@ class TestCheckMigrationVersion_Postgres(unittest.TestCase):
             )
             self.store.initialise()
         except Exception:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:

--- a/tests/test_import_cli.py
+++ b/tests/test_import_cli.py
@@ -80,8 +80,7 @@ class TestImportWithMissingDBFieldPostgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -93,7 +92,7 @@ class TestImportWithMissingDBFieldPostgres(unittest.TestCase):
             )
             self.store.initialise()
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:
@@ -142,8 +141,7 @@ class TestImportWithWrongTypeDBFieldPostgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -155,7 +153,7 @@ class TestImportWithWrongTypeDBFieldPostgres(unittest.TestCase):
             )
             self.store.initialise()
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:
@@ -452,8 +450,7 @@ class TestImportWithMissingDBTablePostgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -465,7 +462,7 @@ class TestImportWithMissingDBTablePostgres(unittest.TestCase):
             )
             self.store.initialise()
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:

--- a/tests/test_import_cli_end_to_end.py
+++ b/tests/test_import_cli_end_to_end.py
@@ -236,8 +236,7 @@ class TestEndToEndAutomaton:
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -250,7 +249,7 @@ class TestEndToEndAutomaton:
             )
             self.store.initialise()
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
         with self.store.session_scope():
             self.store.populate_reference()
 

--- a/tests/test_importers_postgis.py
+++ b/tests/test_importers_postgis.py
@@ -30,8 +30,7 @@ class SampleImporterTestCase(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -43,7 +42,7 @@ class SampleImporterTestCase(unittest.TestCase):
             )
             self.store.initialise()
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self) -> None:
         try:

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -1106,8 +1106,7 @@ class TestMergeStateFromImport_Postgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
 
         self.master_store = DataStore(
             db_name="test",
@@ -2377,8 +2376,7 @@ class TestExportAlterAndMerge_Postgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
 
         self.master_store = DataStore(
             db_name="test",

--- a/tests/test_spatial_data.py
+++ b/tests/test_spatial_data.py
@@ -97,8 +97,7 @@ class SpatialDataPostGISTestCase(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -131,7 +130,7 @@ class SpatialDataPostGISTestCase(unittest.TestCase):
                 state.location = loc
                 self.store.session.add(state)
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
     def tearDown(self):
         try:

--- a/tests/test_tasks_and_participants.py
+++ b/tests/test_tasks_and_participants.py
@@ -333,8 +333,7 @@ class TestTasksAndParticipants_Postgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
 
         self.store = DataStore(
             db_name="test",

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -45,8 +45,7 @@ class TestGPXTimezonePostgres(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
 
         self.postgres_store = DataStore(
             db_name="test",
@@ -95,8 +94,7 @@ class TestTimesEqualDifferentDBs(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
 
         self.postgres_store = DataStore(
             db_name="test",

--- a/tests/test_view_data_cli.py
+++ b/tests/test_view_data_cli.py
@@ -194,8 +194,7 @@ class ViewDataCLIPostgresTestCase(unittest.TestCase):
                 port=55527,
             )
         except RuntimeError:
-            print("PostgreSQL database couldn't be created! Test is skipping.")
-            return
+            raise Exception("Testing Postgres server could not be started/accessed")
         try:
             self.store = DataStore(
                 db_name="test",
@@ -207,7 +206,7 @@ class ViewDataCLIPostgresTestCase(unittest.TestCase):
             )
             self.store.initialise()
         except OperationalError:
-            print("Database schema and data population failed! Test is skipping.")
+            raise Exception("Creating database schema in testing Postgres database failed")
 
         # Parse the REP files
         processor = FileProcessor(archive=False)


### PR DESCRIPTION
## 🧰 Issue
Fixes #951 

## 🚀 Overview: 
Changes all usages of the testing Postgres server to give a proper error if the testing server can't be started. Previously there was a printed message saying that the test was skipping - but the test wasn't actually skipped. Instead, this PR makes the test fail with a custom exception explaining the problem - and because it is a custom exception you can look back in the exception tree and see what exception was actually raised by the testing.Postgresql module.

## 🤔 Reason: 
Give sensible errors in the test suite

## 🔨Work carried out:

- [x] Big find/replace operation to change exception handling in Postgres tests
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
