### PR TITLE
Link16 - skip binary chars in header

### DIFF
--- a/importers/link_16_importer.py
+++ b/importers/link_16_importer.py
@@ -1,6 +1,7 @@
 import os
 import re
 from datetime import datetime, timedelta
+from string import printable
 
 from tqdm import tqdm
 
@@ -44,7 +45,9 @@ class Link16Importer(Importer):
     def can_load_this_header(self, header):
         # V1 starts w/ PPLI
         # V2 starts w/ Xmt/Rcv
-        return header.startswith(V1_HEADER) or header.startswith(V2_HEADER)
+        # Strip any non-ASCII characters from the header
+        ascii_header = "".join(char for char in header if char in printable)
+        return ascii_header.startswith(V1_HEADER) or ascii_header.startswith(V2_HEADER)
 
     def can_load_this_file(self, file_contents):
         return True

--- a/tests/sample_data/track_files/Link16/V2_GEV_binary_in_header_16-05-2021T00-00-00.raw-SLOTS_JMSG.csv
+++ b/tests/sample_data/track_files/Link16/V2_GEV_binary_in_header_16-05-2021T00-00-00.raw-SLOTS_JMSG.csv
@@ -1,0 +1,3 @@
+ï»¿Xmt/Rcv,SlotTime,Set,FrameIndex,STN,RI,Packing,PG,Jx.y,MLI,ADDI,RC,TN,Lat,Long,Alt,Crs,Spd,Id,|,1,2,3,4,5,6,7,8
+SomeStr,59:31.6,B,550,2,0,SomeStr,6,J2.2,3,0,0,1832,0.953371727,0.458539269,25124,5,0.972404565,Friend or Foe,|,Some Hash,Some Hash,,,,,,
+SomeStr,18:45.2,B,560,669,1,SomeStr,6,J3.3,6,0,0,1580,0.762199436,0.296645626,76355,26,0.832872258,Friend or Foe,|,Some Hash,Some Hash,,,,,,

--- a/tests/test_load_link16.py
+++ b/tests/test_load_link16.py
@@ -230,6 +230,20 @@ class TestLoadLink16(unittest.TestCase):
         processor = FileProcessor(archive=False)
         processor.register_importer(Link16Importer())
 
+        # check states empty
+        with self.store.session_scope():
+            # there must be no states at the beginning
+            states = self.store.session.query(self.store.db_classes.State).all()
+            assert len(states) == 0
+
+            # there must be no platforms at the beginning
+            platforms = self.store.session.query(self.store.db_classes.Platform).all()
+            assert len(platforms) == 0
+
+            # there must be no datafiles at the beginning
+            datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
+            assert len(datafiles) == 0
+
         # parse the data
         processor.process(DATA_PATH_MIDDLE_DATE, self.store, False)
 
@@ -270,6 +284,20 @@ class TestLoadLink16(unittest.TestCase):
     def test_file_with_hours(self):
         processor = FileProcessor(archive=False)
         processor.register_importer(Link16Importer())
+
+        # check states empty
+        with self.store.session_scope():
+            # there must be no states at the beginning
+            states = self.store.session.query(self.store.db_classes.State).all()
+            assert len(states) == 0
+
+            # there must be no platforms at the beginning
+            platforms = self.store.session.query(self.store.db_classes.Platform).all()
+            assert len(platforms) == 0
+
+            # there must be no datafiles at the beginning
+            datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
+            assert len(datafiles) == 0
 
         # parse the data
         processor.process(DATA_PATH_HOURS_IN_DATA, self.store, False)
@@ -336,6 +364,20 @@ class TestLoadLink16(unittest.TestCase):
         processor = FileProcessor(archive=False)
         processor.register_importer(Link16Importer())
 
+        # check states empty
+        with self.store.session_scope():
+            # there must be no states at the beginning
+            states = self.store.session.query(self.store.db_classes.State).all()
+            assert len(states) == 0
+
+            # there must be no platforms at the beginning
+            platforms = self.store.session.query(self.store.db_classes.Platform).all()
+            assert len(platforms) == 0
+
+            # there must be no datafiles at the beginning
+            datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
+            assert len(datafiles) == 0
+
         # parse the data
         processor.process(DATA_PATH_TIGHT_ROLLOVER, self.store, False)
 
@@ -368,6 +410,20 @@ class TestLoadLink16(unittest.TestCase):
     def test_binary_in_header(self):
         processor = FileProcessor(archive=False)
         processor.register_importer(Link16Importer())
+
+        # check states empty
+        with self.store.session_scope():
+            # there must be no states at the beginning
+            states = self.store.session.query(self.store.db_classes.State).all()
+            assert len(states) == 0
+
+            # there must be no platforms at the beginning
+            platforms = self.store.session.query(self.store.db_classes.Platform).all()
+            assert len(platforms) == 0
+
+            # there must be no datafiles at the beginning
+            datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
+            assert len(datafiles) == 0
 
         # parse the data
         processor.process(DATA_PATH_BINARY_IN_HEADER, self.store, False)


### PR DESCRIPTION
## 🧰 Issue
Fixes #1059 

## 🚀 Overview: 
Stripped binary characters from the Link16 header

## 🤔 Reason: 
Some data files had binary characters prefixed (possibly an artefact of the conversion from RAW to CSV data) which stopped the importer from recognising the data as one of the Link16 formats.

## 🔨Work carried out:
- [x] Tests pass
- [x] Loads Link16 files with binary characters prefixed to the header

## Confirmations

- [x] I have chosen reviewers for my PR. 
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->

