### PR TITLE
Upgrade to Sphinx v4

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt
+    - requirements: requirements_dev.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ flake8==3.*
 tox==3.14.0
 coverage==5.*
 pytest>=5.3.5
-Sphinx==3.*
+Sphinx==4.*
 twine==3.*
 nose2
 black


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
Builds on ReadTheDocs were failing because we had an old version of Sphinx. This PR upgrades to the latest Sphinx version.

## 🔗 Link to preview (or screenshot, if relevant)
See ReadTheDocs link in the CI section.

## 🤔 Reason: 
Fix failure on ReadTheDocs.

## 🔨Work carried out:

- [x] Upgrade requirement
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.