### PR TITLE
Add MacOS developer setup guide

### DIFF
--- a/DeveloperGuide.rst
+++ b/DeveloperGuide.rst
@@ -95,20 +95,23 @@ The conda package manager can be quite slow, so the instructions show how to ins
 These instructions are for Macs with a M1 (ARM) processor. A similar approach will work for x86 (Intel) Macs, but you will need
 to ensure that you install the Intel version of miniconda.
 
-1. Install the ARM version of mambaforge, which is available `here <https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-arm64.sh>`_, following all the instructions to the end (including setting up integration with your shell)
+1. Install Postgres.app, available from `here <https://postgresapp.com/>`_, which is a self-contained installation of Postgres and PostGIS for MacOS.
 
-2. Create a new environment (like conda's equivalent of a virtualenv) by running: ``mamba create -n pepys python=3.9 libspatialite``. This will
+2. Once installed, add the Postgres bin directory to your PATH. This will be _inside_ the Postgres.app file you've just installed, and the path will be something
+   like :code:`/Applications/Postgres.app/Contents/Versions/14/bin`.
+
+3. Install the ARM version of mambaforge, which is available `here <https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-arm64.sh>`_, following all the instructions to the end (including setting up integration with your shell)
+
+4. Create a new environment (like conda's equivalent of a virtualenv) by running: ``mamba create -n pepys python=3.9 libspatialite psycopg2``. This will
    install Python 3.9 and libspatialite in a new environment called ``pepys``.
 
-3. Activate the environment by running ``mamba activate pepys``
+5. Activate the environment by running ``mamba activate pepys``
 
-4. Install the other Pepys dependencies by running ``pip install -r requirements.txt -r requirements_dev.txt``
+6. Install the other Pepys dependencies by running ``pip install -r requirements.txt -r requirements_dev.txt``
 
-5. Install the Pepys package itself in 'editable mode' by running ``pip install -e .``
+7. Install the Pepys package itself in 'editable mode' by running ``pip install -e .``
 
-6. Install Postgres.app, available from `here <https://postgresapp.com/>`_, which is a self-contained installation of Postgres and PostGIS for MacOS.
-
-7. **Important:** Skip to the :ref:`Run the unit tests` section without following the intermediate steps of the guide.
+8.  **Important:** Skip to the :ref:`Run the unit tests` section without following the intermediate steps of the guide.
 
 
 Windows

--- a/DeveloperGuide.rst
+++ b/DeveloperGuide.rst
@@ -97,8 +97,7 @@ to ensure that you install the Intel version of miniconda.
 
 1. Install Postgres.app, available from `here <https://postgresapp.com/>`_, which is a self-contained installation of Postgres and PostGIS for MacOS.
 
-2. Once installed, add the Postgres bin directory to your PATH. Note: this doesn't have to be in the profile, it can be applied just to the current
-   session, since it is only needed for ``pip install`` step. The bin directory will be _inside_ the Postgres.app file you've just installed, and the path will be something
+2. Once installed, add the Postgres bin directory to the PATH variable in your proefile. The bin directory will be _inside_ the Postgres.app file you've just installed, and the path will be something
    like :code:`/Applications/Postgres.app/Contents/Versions/14/bin`.
 
 3. Install the ARM version of mambaforge, which is available `here <https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-arm64.sh>`_, following 

--- a/DeveloperGuide.rst
+++ b/DeveloperGuide.rst
@@ -88,10 +88,27 @@ Run the following command::
 Mac OS X
 ^^^^^^^^
 
-**Note:** These instructions are not complete due to not having a bare OS X machine to test on. However,
-they should give you some hints as to how to get an OS X machine set up to develop pepys-import.
+The easiest way to get the relevant libraries working on a M1 MacOS machine is to use the conda Python package manager which will install from the
+packages provided by conda-forge. This is different to the standard pip/virtualenv process, but works quite nicely alongside it.
+The conda package manager can be quite slow, so the instructions show how to install mamba instead, which is a faster fork.
 
-**TODO - Complete instructions here**
+These instructions are for Macs with a M1 (ARM) processor. A similar approach will work for x86 (Intel) Macs, but you will need
+to ensure that you install the Intel version of miniconda.
+
+1. Install the ARM version of mambaforge, which is available `here <https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-arm64.sh>`_, following all the instructions to the end (including setting up integration with your shell)
+
+2. Create a new environment (like conda's equivalent of a virtualenv) by running: ``mamba create -n pepys python=3.9 libspatialite``. This will
+   install Python 3.9 and libspatialite in a new environment called ``pepys``.
+
+3. Activate the environment by running ``mamba activate pepys``
+
+4. Install the other Pepys dependencies by running ``pip install -r requirements.txt -r requirements_dev.txt``
+
+5. Install the Pepys package itself in 'editable mode' by running ``pip install -e .``
+
+6. Install Postgres.app, available from `here <https://postgresapp.com/>`_, which is a self-contained installation of Postgres and PostGIS for MacOS.
+
+7. **Important:** Skip to the :ref:`Run the unit tests` section without following the intermediate steps of the guide.
 
 
 Windows

--- a/DeveloperGuide.rst
+++ b/DeveloperGuide.rst
@@ -97,10 +97,12 @@ to ensure that you install the Intel version of miniconda.
 
 1. Install Postgres.app, available from `here <https://postgresapp.com/>`_, which is a self-contained installation of Postgres and PostGIS for MacOS.
 
-2. Once installed, add the Postgres bin directory to your PATH. This will be _inside_ the Postgres.app file you've just installed, and the path will be something
+2. Once installed, add the Postgres bin directory to your PATH. Note: this doesn't have to be in the profile, it can be applied just to the current
+   session, since it is only needed for ``pip install`` step. The bin directory will be _inside_ the Postgres.app file you've just installed, and the path will be something
    like :code:`/Applications/Postgres.app/Contents/Versions/14/bin`.
 
-3. Install the ARM version of mambaforge, which is available `here <https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-arm64.sh>`_, following all the instructions to the end (including setting up integration with your shell)
+3. Install the ARM version of mambaforge, which is available `here <https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-arm64.sh>`_, following 
+    all the instructions to the end (including setting up integration with your shell)
 
 4. Create a new environment (like conda's equivalent of a virtualenv) by running: ``mamba create -n pepys python=3.9 libspatialite psycopg2``. This will
    install Python 3.9 and libspatialite in a new environment called ``pepys``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.todo",
+    "sphinx.ext.autosectionlabel",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## 🧰 Issue
Fixes #925

## 🚀 Overview: 
Adds MacOS developer setup guide

## 🤔 Reason: 
Add guide for MacOS developers

## 🔨Work carried out:

- [x] Update developer setup guide
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
@IanMayo Could you test these instructions? They worked for me on a clean MacBook, but it is possible I've missed a step somewhere.