### PR TITLE
Prepend the Pepys path to the PATH variable, rather than appending it

### DIFF
--- a/bin/install_pepys.ps1
+++ b/bin/install_pepys.ps1
@@ -111,7 +111,7 @@ try {
     if (!($env:Path -split ';' -contains $pepys_bin_path)) {
         [Environment]::SetEnvironmentVariable(
             "PATH",
-            [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User) + ";" + $pepys_bin_path,
+            $pepys_bin_path + ";" + [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User),
             [EnvironmentVariableTarget]::User)
     }
 }


### PR DESCRIPTION
## 🧰 Issue
Fixes #1107.

## 🚀 Overview: 
Changes the installation script to _prepend_ the Pepys path to the `PATH` environment variable, so it takes priority over other entries on the path.

## 🤔 Reason: 
So the correct version of Pepys is used.

## 🔨Work carried out:

- [x] Modify install pepys script
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.