### PR TITLE
1109 new jchat format

### DIFF
--- a/importers/jchat_importer.py
+++ b/importers/jchat_importer.py
@@ -122,20 +122,23 @@ class JChatImporter(Importer):
             # Older format uses id=
             # Newer format uses msgid=
             msg_id = div.attrib["msgid"]  # Grabbing ID to help with error reporting
-            version = JCHAT_MODERN
         except KeyError:
             try:
                 msg_id = div.attrib["id"]
-                version = JCHAT_LEGACY
             except KeyError:
                 # Ignore any non-comment messages (e.g. connect/disconnect)
                 return
 
-        time_element = div.find("{*}tt/font")
-
         # Sample data included some "Marker" messages with the id="marker"
         if str.upper(msg_id) == "MARKER":
             return  # Ignore these messages
+
+        text_blocks = []
+        text_blocks.append([item for item in div.findall(".//*") if item.text])
+        if text_blocks[0]:
+            time_element = text_blocks[0][0]
+            platform_element = text_blocks[0][1]
+            msg_content_element = text_blocks[0][2:]
 
         if time_element is None:
             self.errors.append(
@@ -147,11 +150,6 @@ class JChatImporter(Importer):
         timestamp = self.parse_timestamp(time_string, msg_id)
         time_element.record(self.name, "timestamp", timestamp)
 
-        if version == JCHAT_LEGACY:
-            platform_element = div.find("{*}b/a/font")
-        else:  # version == JCHAT_MODERN
-            platform_element = div.find("{*}b/font/a")
-
         if platform_element is None:
             self.errors.append(
                 {self.error_type: f"Unable to read message {msg_id}. No platform provided"}
@@ -162,14 +160,13 @@ class JChatImporter(Importer):
         # Match on quadgraphs
         platform = self.get_cached_platform_from_quad(data_store, platform_quad, change_id)
 
-        msg_content_element = [element for element in div.iterfind("font")]
-
         if not msg_content_element:
             self.errors.append(
                 {self.error_type: f"Unable to read message {msg_id}. No message provided"}
             )
             return
         msg_content = self.parse_message_content(msg_content_element)
+        print(msg_content)
         if not msg_content:
             self.errors.append({self.error_type: f"Unable to parse JChat message {msg_id}."})
             return

--- a/importers/jchat_importer.py
+++ b/importers/jchat_importer.py
@@ -140,9 +140,11 @@ class JChatImporter(Importer):
             platform_element = text_blocks[0][1]
             msg_content_element = text_blocks[0][2:]
 
-        if time_element is None:
+        if not text_blocks[0] or len(text_blocks[0]) < 3:
             self.errors.append(
-                {self.error_type: f"Unable to read message {msg_id}. No timestamp provided"}
+                {
+                    self.error_type: f"Unable to read message {msg_id}. Not enough parts (expecting timestamp, platform, message)"
+                }
             )
             return
 
@@ -150,23 +152,13 @@ class JChatImporter(Importer):
         timestamp = self.parse_timestamp(time_string, msg_id)
         time_element.record(self.name, "timestamp", timestamp)
 
-        if platform_element is None:
-            self.errors.append(
-                {self.error_type: f"Unable to read message {msg_id}. No platform provided"}
-            )
-            return
         platform_quad = platform_element.text[0:4]
         platform_element.record(self.name, "platform", platform_quad)
         # Match on quadgraphs
         platform = self.get_cached_platform_from_quad(data_store, platform_quad, change_id)
 
-        if not msg_content_element:
-            self.errors.append(
-                {self.error_type: f"Unable to read message {msg_id}. No message provided"}
-            )
-            return
         msg_content = self.parse_message_content(msg_content_element)
-        print(msg_content)
+
         if not msg_content:
             self.errors.append({self.error_type: f"Unable to parse JChat message {msg_id}."})
             return

--- a/tests/sample_data/jchat_files/combined_format.html
+++ b/tests/sample_data/jchat_files/combined_format.html
@@ -22,5 +22,11 @@
   <div id="34abc=34537">
     <tt><font>[08010809A]</font></tt><b><a href=""><font>ABCD_CMD</font></a></b><font><i>Legacy - font a swap - has i tag - no breaks</i></font>
   </div>
+  <div msgid="34bbb=34236">
+    <font><tt>[23112654A]</tt></font><font><b><a href="">SPLA_AB</a></font></b><font>Modern 2 - <br>no i tag<br>but has multiple<br>breaks</font>
+  </div>
+  <div msgid="34bbb=34235">
+    <font><tt>[06010709A]</tt></font><font><b><a href="">SPLB_XO</a></font></b><font>Modern 2 - no i tag - no breaks</font>
+  </div>
 </body>
 </html>

--- a/tests/test_load_jchat.py
+++ b/tests/test_load_jchat.py
@@ -495,11 +495,11 @@ class JChatTests(unittest.TestCase):
         with self.store.session_scope():
             # there must be states after the import
             comments = self.store.session.query(self.store.db_classes.Comment).all()
-            assert len(comments) == 5
+            assert len(comments) == 7
 
             # there must be platforms after the import
             platforms = self.store.session.query(self.store.db_classes.Platform).all()
-            assert len(platforms) == 3
+            assert len(platforms) == 5
 
             # there must be one datafile afterwards
             datafiles = self.store.session.query(self.store.db_classes.Datafile).all()
@@ -510,12 +510,14 @@ class JChatTests(unittest.TestCase):
                 .order_by(self.store.db_classes.Comment.time)
                 .all()
             )
-            assert len(results) == 5
+            assert len(results) == 7
             assert results[0].content == "Modern - has i tag"
             assert results[1].content == "Modern - no i tag but has multiple breaks"
             assert results[2].content == "Modern - no i tag - no breaks"
             assert results[3].content == "Legacy - font a swap - no i tag - no breaks"
             assert results[4].content == "Legacy - font a swap - has i tag - no breaks"
+            assert results[5].content == "Modern 2 - no i tag but has multiple breaks"
+            assert results[6].content == "Modern 2 - no i tag - no breaks"
 
     def test_invalid_missing_timestamp(self):
         html_string = """<html>

--- a/tests/test_load_jchat.py
+++ b/tests/test_load_jchat.py
@@ -539,7 +539,7 @@ class JChatTests(unittest.TestCase):
 
         check_errors_for_file_contents(
             html_string,
-            "Unable to read message 34544=34534. No timestamp provided",
+            "Unable to read message 34544=34534. Not enough parts (expecting timestamp, platform, message)",
             importer,
             "no_timestamp.html",
         )
@@ -590,7 +590,7 @@ class JChatTests(unittest.TestCase):
 
         check_errors_for_file_contents(
             html_string,
-            "Unable to read message 34544=34534. No platform provided",
+            "Unable to read message 34544=34534. Not enough parts (expecting timestamp, platform, message)",
             importer,
             "no_platform.html",
         )
@@ -615,7 +615,7 @@ class JChatTests(unittest.TestCase):
 
         check_errors_for_file_contents(
             html_string,
-            "Unable to read message 34544=34534. No message provided",
+            "Unable to read message 34544=34534. Not enough parts (expecting timestamp, platform, message)",
             importer,
             "no_message",
         )
@@ -640,7 +640,10 @@ class JChatTests(unittest.TestCase):
         importer = JChatImporter()
 
         check_errors_for_file_contents(
-            html_string, "Unable to parse JChat message 34544=34534.", importer, "no_message"
+            html_string,
+            "Unable to read message 34544=34534. Not enough parts (expecting timestamp, platform, message)",
+            importer,
+            "no_message",
         )
 
     @staticmethod


### PR DESCRIPTION
## 🧰 Issue
Fixes #1109 

## 🚀 Overview: 
Added support for new JChat format using a slightly more generic approach that assumes that all JChat messages are always ordered as: timestamp - platform - message (which seems to be more reliably true than the order of the tags...)

## 🤔 Reason: 
To add support for another JChat format

## 🔨Work carried out:

- [x] Support added for new JChat format
- [x] More generic approach to support other combinations of tags 
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
