### PR TITLE
Fix SQLAlchemy version to v1.4.27, as v1.4.28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-SQLAlchemy==1.4.*
+SQLAlchemy==1.4.27
 geoalchemy2>=0.9.4
 psycopg2==2.8.*
 pint==0.14


### PR DESCRIPTION
## 🧰 Issue
Fixes #1112.

## 🚀 Overview: 
SQLAlchemy v1.4.28 emits more warnings in various situations (see [here](https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html#change-02be00a13dbc11e614061ad1a5c7f1f6). These warnings are triggered by various geoalchemy functions we use. In our CI, we have it set to turn warnings into errors - which is a good idea in general, but means that we can get unexpected errors from dependencies being upgraded by minor point releases which change warnings rules.

The requirement for SQLAlchemy just required v1.4.x, which is normally ok as breaking changes shouldn't occur in a point release - but this doesn't apply to warnings. So, this PR fixes the version to v1.4.27.

There is already a [PR](https://github.com/geoalchemy/geoalchemy2/pull/338) in geoalchemy2 to fix these warnings, so once that PR is merged and a new version is released, then we can stop fixing the point version.

## 🤔 Reason: 
Fix CI.

## 🔨Work carried out:

- [x] Fix version of SQLAlchemy
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->

