### PR TITLE
Fix black style issues, and pin black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/python/black
-    rev: 21.9b0
+    rev: 22.1.0
     hooks:
       - id: black
         language_version: python3

--- a/importers/eag_importer.py
+++ b/importers/eag_importer.py
@@ -217,23 +217,23 @@ class EAGImporter(Importer):
         # Parameters for WGS-84 ellipsoid
         a = 6378137
         b = 6356752.31424518
-        e = math.sqrt((a ** 2 - b ** 2) / (a ** 2))
-        e_dash = math.sqrt((a ** 2 - b ** 2) / (b ** 2))
+        e = math.sqrt((a**2 - b**2) / (a**2))
+        e_dash = math.sqrt((a**2 - b**2) / (b**2))
 
         # Auxilliary values
-        p = math.sqrt(ecef_x ** 2 + ecef_y ** 2)
+        p = math.sqrt(ecef_x**2 + ecef_y**2)
         theta = math.atan((ecef_z * a) / (p * b))
 
         # Calculate longitude from ECEF X and Y as:
         # longitude = arctan(Y / X)
         longitude = math.degrees(math.atan((ecef_y / ecef_x)))
 
-        top_lat_frac = ecef_z + (e_dash ** 2) * b * (math.sin(theta) ** 3)
-        bottom_lat_frac = p - (e ** 2) * a * (math.cos(theta) ** 3)
+        top_lat_frac = ecef_z + (e_dash**2) * b * (math.sin(theta) ** 3)
+        bottom_lat_frac = p - (e**2) * a * (math.cos(theta) ** 3)
 
         latitude = math.degrees(math.atan(top_lat_frac / bottom_lat_frac))
 
-        Ntemp = math.sqrt(1 - (e ** 2) * (math.sin(math.radians(latitude)) ** 2))
+        Ntemp = math.sqrt(1 - (e**2) * (math.sin(math.radians(latitude)) ** 2))
 
         N = a / Ntemp
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,7 @@ pytest>=5.3.5
 Sphinx==4.*
 twine==3.*
 nose2
-black
+black==22.1.0
 pre-commit
 sphinx_rtd_theme
 git+https://github.com/tk0miya/testing.postgresql.git#egg=testing.postgresql


### PR DESCRIPTION
## 🧰 Issue
N/A

## 🚀 Overview: 
This PR fixes some black style issues that were causing the CI tests to fail, and pins the black version to the latest stable version (22.1.0) in both the pre-commit config file, and the requirements_dev.txt file.

## 🤔 Reason: 
Get the same black version everywhere we use it (locally and CI)

## 🔨Work carried out:

- [x] Update requirements.txt
- [x] Update pre-commit config
- [x] Run black
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.

## 📝 Developer Notes:
If you're going to be contributing code that you've edited on your local machine @IanMayo, it's probably worth doing a `pip install -U black` to upgrade. pre-commit should upgrade its version automatically next time it's used.
