### PR TITLE
Fix bug causing Python to completely crash when merging databases

### DIFF
--- a/pepys_admin/merge.py
+++ b/pepys_admin/merge.py
@@ -361,9 +361,9 @@ class MergeDatabases:
                     for result in results:
                         result.entity = to_id
 
-                # Commit changes
-                self.slave_store.session.add_all(results)
-                self.slave_store.session.commit()
+                    # Commit changes
+                    self.slave_store.session.add_all(results)
+                    self.slave_store.session.commit()
 
     def update_logs_table(self, modified_ids):
         """Updates the Logs table in the slave_store for entries which have had their GUID modified
@@ -392,9 +392,9 @@ class MergeDatabases:
                     for result in results:
                         result.id = to_id
 
-                # Commit changes
-                self.slave_store.session.add_all(results)
-                self.slave_store.session.commit()
+                    # Commit changes
+                    self.slave_store.session.add_all(results)
+                    self.slave_store.session.commit()
 
     @staticmethod
     def split_list(lst, n=100):

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -2103,6 +2103,40 @@ class TestMergeUpdatePlatformPrivacy(unittest.TestCase):
                 assert len(results) == 1
 
 
+class TestTwoPopulatedDatabasesMerge(unittest.TestCase):
+    def setUp(self):
+        if os.path.exists("master.sqlite"):
+            os.remove("master.sqlite")
+
+        if os.path.exists("slave.sqlite"):
+            os.remove("slave.sqlite")
+
+        self.master_store = DataStore("", "", "", 0, db_name="master.sqlite", db_type="sqlite")
+        self.master_store.initialise()
+
+        with self.master_store.session_scope():
+            self.master_store.populate_reference()
+            self.master_store.populate_metadata()
+
+        self.slave_store = DataStore("", "", "", 0, db_name="slave.sqlite", db_type="sqlite")
+        self.slave_store.initialise()
+
+        with self.slave_store.session_scope():
+            self.slave_store.populate_reference()
+            self.slave_store.populate_metadata()
+
+    def tearDown(self):
+        if os.path.exists("master.sqlite"):
+            os.remove("master.sqlite")
+
+        if os.path.exists("slave.sqlite"):
+            os.remove("slave.sqlite")
+
+    def test_two_populated_databases_merge(self):
+        self.merge_class = MergeDatabases(self.master_store, self.slave_store)
+        self.merge_class.merge_all_tables()
+
+
 class TestExportAlterAndMerge(unittest.TestCase):
     @patch("pepys_admin.snapshot_cli.ptk_prompt", return_value="slave_exported.sqlite")
     @patch("pepys_admin.snapshot_cli.iterfzf", return_value=["Public"])


### PR DESCRIPTION
## 🧰 Issue
Fixes #1121 

## 🚀 Overview: 
Fixes an issue where Python crashed (completely - to the extent that Windows reported a problem with Python, or it just exited completely) when merging databases. After a lot of debugging (see comments on #1121) it seems this was caused by calls to `session.add_all()` and `session.commit()` being called a number of times in a loop with no work to do. This was a bug in our code, but also something that I wouldn't have expected to have caused a full crash - instead I'd have expected the calls to basically be no-ops.

This PR fixes this by putting these calls _inside_ the if statement that checks whether there is anything that needs changing, so they only get called if there is actually something to do.

I suspect the reason that this occurred on Windows and not MacOS or Linux is that Windows can be more picky about resource limits and access to resources in general, and it may have reached some limit that caused a crash. That is just my guess though.

I will attempt to put together a minimal example and report this bug to the SQLAlchemy developers.

## 🤔 Reason: 
Fix crashing bug.

## 🔨Work carried out:

- [x] Debug issue
- [x] Fix bug
- [x] Add test
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have chosen an appropriate label for the PR, adding `interactive_review` if reviewers will need to see UI
- [x] I have extended/updated the documentation in `\docs` folder
- [x] Any database content changes (Create, Edit, Delete) are recorded in the Log/Changes tables
- [x] Any database schema changes are implemented via `alembic revision` [transitions](https://pepys-import.readthedocs.io/en/latest/database_migration.html#how-to-use-it-for-developers)
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.